### PR TITLE
Fix: Replace code_interpreter.kill() with code_interpreter.close()

### DIFF
--- a/examples/langchain-python/langchain_code_interpreter.ipynb
+++ b/examples/langchain-python/langchain_code_interpreter.ipynb
@@ -330,7 +330,7 @@
     "# 5. Invoke the agent\n",
     "result = agent_executor.invoke({\"input\": \"plot and show sinus\"})\n",
     "\n",
-    "code_interpreter.kill()\n",
+    "code_interpreter.close()\n",
     "\n",
     "# Each intermediate step is a Tuple[ToolAgentAction, dict]\n",
     "result[\"intermediate_steps\"][0][1][\"results\"][0]"


### PR DESCRIPTION
Replaced the incorrect `code_interpreter.kill()` method with the correct `code_interpreter.close()` method. This resolves the AttributeError when using the `CodeInterpreter` class. Tested locally to confirm functionality.