### PR TITLE
Fix docker version to 27

### DIFF
--- a/examples/docker-in-e2b/e2b.Dockerfile
+++ b/examples/docker-in-e2b/e2b.Dockerfile
@@ -23,7 +23,7 @@ RUN echo \
     $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 # Install Docker
-RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
+RUN apt-get update && apt-get install -y docker-ce=5:27.1.1-1~ubuntu.20.04~focal docker-ce-cli=5:27.1.1-1~ubuntu.20.04~focal containerd.io
 
 # Clean up
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes docker version to v27 (5:27.1.1-1~ubuntu.20.04~focal), newer version (v28.0.1) doesn't work because of the following error:

```
docker: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint ...: Unable to enable DIRECT ACCESS FILTERING - DROP rule:  (iptables failed: iptables --wait -t raw -A PREROUTING -p tcp -d 172.17.0.2 --dport 8000 ! -i docker0 -j DROP: iptables v1.8.4 (legacy): can't initialize iptables table `raw': Table does not exist (do you need to insmod?)
Perhaps iptables or your kernel needs to be upgraded.
 (exit status 3))
```