### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/examples/autogen-python/poetry.lock
+++ b/examples/autogen-python/poetry.lock
@@ -514,14 +514,14 @@ files = [
 ]
 
 [[package]]
-name = "pyautogen"
+name = "ag2"
 version = "0.3.0"
 description = "A programming framework for agentic AI"
 optional = false
 python-versions = "<3.13,>=3.8"
 files = [
-    {file = "pyautogen-0.3.0-py3-none-any.whl", hash = "sha256:af5677de9216823b05f52fd1e6d359ddb332dcb68cdf58acf3b0f4a9a796d302"},
-    {file = "pyautogen-0.3.0.tar.gz", hash = "sha256:dcd8239ed33d7a698a6bb2ed71a631fded4b4f6bd861a5cd854ab960f91bdabe"},
+    {file = "ag2-0.3.0-py3-none-any.whl", hash = "sha256:af5677de9216823b05f52fd1e6d359ddb332dcb68cdf58acf3b0f4a9a796d302"},
+    {file = "ag2-0.3.0.tar.gz", hash = "sha256:dcd8239ed33d7a698a6bb2ed71a631fded4b4f6bd861a5cd854ab960f91bdabe"},
 ]
 
 [package.dependencies]

--- a/examples/autogen-python/pyproject.toml
+++ b/examples/autogen-python/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.13"
-pyautogen = "^0.3.0"
+ag2 = "^0.3.0"
 e2b = "0.17.2a60"
 python-dotenv = "^1.0.0"
 


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
