### PR TITLE
feat: add Soulink agent identity example

### DIFF
--- a/examples/soulink-agent-identity-js/README.md
+++ b/examples/soulink-agent-identity-js/README.md
@@ -1,0 +1,35 @@
+# Soulink Agent Identity for E2B Sandboxes
+
+This example shows how to give [E2B Sandbox](https://e2b.dev/docs/quickstart) agents verified on-chain identities using [Soulink](https://soulink.dev).
+
+Sandbox agents are ephemeral and anonymous by default. Soulink gives them persistent, verifiable `.agent` names on Base — the identity outlives the sandbox, and reputation accrues across sessions.
+
+## What this does
+
+1. Resolves an agent's `.agent` identity from Soulink before sandbox creation
+2. Checks the agent's on-chain credit score (reputation based on peer reports)
+3. Injects identity context into the sandbox so code inside knows "who it is"
+4. Demonstrates verifying another agent's identity from within the sandbox
+
+## Setup & run
+
+### 1. Install dependencies
+```
+npm install
+```
+
+### 2. Set up `.env`
+
+1. Copy `.env.template` to `.env`
+2. Get [E2B API key](https://e2b.dev/docs/getting-started/api-key)
+
+### 3. Run the example
+```
+npm run start
+```
+
+## Learn more
+
+- [Soulink API docs](https://soulink.dev/skill.md)
+- [Register a .agent name](https://soulink.dev)
+- [E2B Documentation](https://e2b.dev/docs)

--- a/examples/soulink-agent-identity-js/index.ts
+++ b/examples/soulink-agent-identity-js/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Soulink Agent Identity for E2B Sandboxes
+ *
+ * Gives sandboxed agents verified on-chain identities. By resolving a
+ * Soulink .agent name before sandbox creation, each agent instance gets
+ * a verifiable identity that other agents can authenticate against.
+ * The identity persists on-chain even after the sandbox terminates.
+ *
+ * Soulink: https://soulink.dev
+ */
+import 'dotenv/config'
+import { Sandbox } from '@e2b/code-interpreter'
+
+const SOULINK_API = 'https://soulink.dev/api/v1'
+
+interface SoulinkIdentity {
+  name: string
+  owner: string
+  expires_at: string
+}
+
+interface SoulinkCredit {
+  name: string
+  score: number
+  total_reports: number
+}
+
+async function resolveAgent(name: string): Promise<SoulinkIdentity> {
+  const res = await fetch(`${SOULINK_API}/resolve/${encodeURIComponent(name)}`)
+  if (!res.ok) throw new Error(`Failed to resolve ${name}: ${res.status}`)
+  return res.json() as Promise<SoulinkIdentity>
+}
+
+async function getCredit(name: string): Promise<SoulinkCredit> {
+  const res = await fetch(`${SOULINK_API}/credit/${encodeURIComponent(name)}`)
+  if (!res.ok) throw new Error(`Failed to get credit for ${name}: ${res.status}`)
+  return res.json() as Promise<SoulinkCredit>
+}
+
+async function run() {
+  // 1. Resolve agent identity from Soulink before entering sandbox
+  const agentName = 'my-agent'
+  const identity = await resolveAgent(agentName)
+  const credit = await getCredit(agentName)
+
+  console.log(`Agent: ${identity.name}.agent`)
+  console.log(`Owner: ${identity.owner}`)
+  console.log(`Credit: ${credit.score}/100 (${credit.total_reports} reports)`)
+
+  // 2. Create sandbox with identity context
+  const sbx = await Sandbox.create()
+
+  // 3. Inject identity into sandbox environment
+  const execution = await sbx.runCode(`
+import json
+import urllib.request
+
+# Agent identity injected from host
+IDENTITY = ${JSON.stringify({ name: identity.name, owner: identity.owner, score: credit.score })}
+
+print(f"Running as: {IDENTITY['name']}.agent")
+print(f"Credit score: {IDENTITY['score']}/100")
+
+# Verify another agent before interacting
+def verify_agent(target_name):
+    """Check another agent's identity and trust score before interaction."""
+    url = f"https://soulink.dev/api/v1/credit/{target_name}"
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req) as response:
+        data = json.loads(response.read())
+        print(f"Target {target_name}: score={data.get('score', 'unknown')}/100")
+        return data
+
+# Example: check if a target agent is trustworthy
+result = verify_agent("helper-bot")
+print(json.dumps(result, indent=2))
+`)
+
+  console.log('Sandbox output:', execution.logs.stdout.join('\n'))
+
+  await sbx.kill()
+}
+
+run().catch(console.error)

--- a/examples/soulink-agent-identity-js/package.json
+++ b/examples/soulink-agent-identity-js/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "soulink-agent-identity",
+  "version": "1.0.0",
+  "description": "Give E2B sandbox agents verified on-chain identities via Soulink",
+  "main": "index.js",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "keywords": ["e2b", "soulink", "agent-identity"],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^20.16.6",
+    "tsx": "^4.7.3",
+    "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "@e2b/code-interpreter": "^1.0.1",
+    "dotenv": "^16.4.5"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a cookbook example showing how to give E2B sandbox agents verified on-chain identities using [Soulink](https://soulink.dev).

- **Resolve** agent `.agent` identity before sandbox creation
- **Check** on-chain credit score (peer-reported reputation)
- **Inject** identity context into sandbox so code knows "who it is"
- **Verify** other agents from within the sandbox before interacting

## Why this pairing

E2B sandbox agents are ephemeral and anonymous by default. Soulink gives them persistent, verifiable `.agent` names on Base — the identity outlives the sandbox, and reputation accrues across sessions. Useful for enterprise teams needing agent accountability.

## What's changed

- Added `examples/soulink-agent-identity-js/` with `index.ts`, `package.json`, and `README.md`
- Follows the same structure as existing cookbook examples (e.g., `hello-world-js`)

## Links

- [Soulink](https://soulink.dev) — On-chain identity for AI agents
- [Soulink API](https://soulink.dev/skill.md) — Agent-readable API guide