### PR TITLE
feat: add sandbox-agent sdk example

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ Read more about E2B on the [E2B website](https://e2b.dev) and the official [E2B 
       <td><a href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/agentkit-coding-agent">TypeScript</a></td>
     </tr>
     <tr>
+    <td>Sandbox Agent SDK</td>
+      <td>Run Sandbox Agent inside E2B and connect with the SDK</td>
+      <td>-</td>
+      <td><a href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/sandbox-agent-sdk-js">TypeScript</a></td>
+    </tr>
+    <tr>
       <td>Stirrup</td>
       <td>The lightweight framework for building agents</td>
       <td><a href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/stirrup-python">Python</a></td>

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Read more about E2B on the [E2B website](https://e2b.dev) and the official [E2B 
       <td><a href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/agentkit-coding-agent">TypeScript</a></td>
     </tr>
     <tr>
-    <td>Sandbox Agent SDK</td>
+    <td><a href="https://sandboxagent.dev/docs/sdk-overview">Sandbox Agent SDK</a></td>
       <td>Run Sandbox Agent inside E2B and connect with the SDK</td>
       <td>-</td>
       <td><a href="https://github.com/e2b-dev/e2b-cookbook/tree/main/examples/sandbox-agent-sdk-js">TypeScript</a></td>

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -47,4 +47,4 @@ This starts up your Sandbox Agent and connects it to your E2B Sandbox. To run on
 - [Sandbox Agent SDK docs](https://sandboxagent.dev/docs/sdk-overview)
 - [Sandbox Agent session persistence](https://sandboxagent.dev/docs/session-persistence)
 - [Sandbox Agent credentials](https://sandboxagent.dev/docs/credentials)
-- [E2B AMP guide](https://e2b.dev/docs/agents/amp)
+- [E2B Sandbox Agent SDK guide](https://e2b.dev/docs/agents/sandbox-agent-sdk)

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -1,0 +1,53 @@
+# Sandbox Agent SDK in E2B Sandbox (JavaScript)
+
+This example shows how to run [Sandbox Agent](https://github.com/rivet-dev/sandbox-agent) inside an E2B sandbox, then connect to it using the Sandbox Agent TypeScript SDK.
+
+## What this example does
+
+1. Creates an E2B sandbox.
+2. Installs Sandbox Agent CLI in the sandbox.
+3. Installs a coding agent (`codex`, `claude`, or any `SANDBOX_AGENT` value).
+4. Starts `sandbox-agent server` in the sandbox.
+5. Connects with `SandboxAgent.connect(...)` and creates a session.
+
+## Why use Sandbox Agent SDK?
+
+- Session lifecycle helpers (`createSession`, `resumeSession`, `destroySession`)
+- Prompt/send helpers (`session.prompt`, `session.send`)
+- Event streaming (`session.onEvent`) without writing transport plumbing
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Create a `.env` file:
+
+```bash
+E2B_API_KEY=your_e2b_api_key
+
+# Provide at least one provider key, unless SANDBOX_AGENT points to a compatible preinstalled agent
+OPENAI_API_KEY=your_openai_api_key
+# CODEX_API_KEY=your_codex_api_key
+# ANTHROPIC_API_KEY=your_anthropic_api_key
+
+# Optional: any specific agent id
+# SANDBOX_AGENT=codex
+```
+
+3. Run the example:
+
+```bash
+npm run start
+```
+
+The script prints an Inspector URL once the server and session are ready, then exits after cleanup.
+
+## Notes
+
+- If `SANDBOX_AGENT` is set, that exact agent ID is used.
+- If `SANDBOX_AGENT` is not set, the script defaults to `codex` when OpenAI/Codex keys exist, otherwise `claude` when Anthropic key exists.
+- API keys are available to processes running inside the sandbox.

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -31,12 +31,9 @@ E2B_API_KEY=your_e2b_api_key
 OPENAI_API_KEY=your_openai_api_key
 # CODEX_API_KEY=your_codex_api_key
 # ANTHROPIC_API_KEY=your_anthropic_api_key
-
-# Optional: use a custom E2B template/snapshot alias
-# E2B_TEMPLATE=base
 ```
 
-Provider credential options for other agents: [Sandbox Agent credentials docs](https://sandboxagent.dev/docs/credentials).
+Provider credential options for other agents: [Sandbox Agent credentials docs](https://sandboxagent.dev/docs/llm-credentials).
 
 3. Run:
 
@@ -44,15 +41,7 @@ Provider credential options for other agents: [Sandbox Agent credentials docs](h
 npm run start
 ```
 
-## What the script does
-
-1. Creates an E2B sandbox (from `E2B_TEMPLATE`, default `base`).
-2. Installs `sandbox-agent` CLI and installs an agent.
-3. Starts `sandbox-agent --no-token server`.
-4. Connects with `SandboxAgent.connect(...)` and creates a session.
-5. Prints an Inspector URL.
-
-To run one prompt and stream events, uncomment the block in `src/index.ts`.
+This starts up your Sandbox Agent and connects it to your E2B Sandbox. To run one prompt and stream events, uncomment the block in `src/index.ts`.
 
 ## References
 

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -12,13 +12,15 @@ This example shows how to run [Sandbox Agent](https://github.com/rivet-dev/sandb
 
 ## Why use Sandbox Agent SDK?
 
-Most coding-agent integrations are provider-specific. If you swap agents, you usually also swap SDKs, event formats, and session plumbing.
+Running coding agents remotely is hard. Existing SDKs assume local execution, SSH breaks streaming and interactive workflows, and every coding agent has a different API.
 
-Sandbox Agent SDK solves that by giving your app one stable API for different coding agents:
+Building this from scratch usually means rewriting everything for each coding agent.
 
-- Agent portability: same app code, different agent selected via `SANDBOX_AGENT`
-- Stable session model: create/resume/destroy sessions the same way across agents
-- Unified interaction model: prompt/send/events without implementing raw transport details
+Sandbox Agent solves three problems:
+
+- **Coding agents need sandboxes:** You can't let AI execute arbitrary code on your production servers. Sandbox Agent runs inside the E2B sandbox and exposes HTTP/SSE.
+- **Every coding agent is different:** Claude Code, Codex, OpenCode, Cursor, Amp, and Pi each have proprietary APIs and event formats. Sandbox Agent provides one API, so swapping agents is a config change (`SANDBOX_AGENT`) instead of a rewrite.
+- **Sessions are ephemeral:** Agent transcripts often die with the sandbox/process. Sandbox Agent emits a universal event schema so you can store, replay, and audit sessions outside the sandbox lifecycle.
 
 ## Setup
 

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -36,10 +36,6 @@ Real-time SSE stream of everything the agent does. Persist to your storage, repl
 
 Standardized session schema that covers all features of all agents. Includes tool calls, permission requests, file edits, etc.
 
-- **Runs Inside Any Sandbox**
-
-Run Sandbox Agent inside E2B, Daytona, Vercel Sandboxes, or Docker.
-
 - **Full Session Lifecycle Management**
 
 Create sessions, send messages, persist transcripts. Full session lifecycle management over HTTP.

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -52,6 +52,12 @@ npm run start
 
 The script prints an Inspector URL once the server and session are ready, then exits after cleanup.
 
+To keep the sandbox running so you can open the Inspector URL, run:
+
+```bash
+KEEP_ALIVE=1 npm run start
+```
+
 ## Notes
 
 - If `SANDBOX_AGENT` is set, that exact agent ID is used.

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -68,6 +68,8 @@ OPENAI_API_KEY=your_openai_api_key
 # CODEX_API_KEY=your_codex_api_key
 # ANTHROPIC_API_KEY=your_anthropic_api_key
 
+# Other agents may require additional credentials. Set any extra provider keys as environment variables.
+
 # Optional: select which agent to run
 # AGENT=codex
 ```

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -12,9 +12,13 @@ This example shows how to run [Sandbox Agent](https://github.com/rivet-dev/sandb
 
 ## Why use Sandbox Agent SDK?
 
-- Session lifecycle helpers (`createSession`, `resumeSession`, `destroySession`)
-- Prompt/send helpers (`session.prompt`, `session.send`)
-- Event streaming (`session.onEvent`) without writing transport plumbing
+Most coding-agent integrations are provider-specific. If you swap agents, you usually also swap SDKs, event formats, and session plumbing.
+
+Sandbox Agent SDK solves that by giving your app one stable API for different coding agents:
+
+- Agent portability: same app code, different agent selected via `SANDBOX_AGENT`
+- Stable session model: create/resume/destroy sessions the same way across agents
+- Unified interaction model: prompt/send/events without implementing raw transport details
 
 ## Setup
 

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -20,7 +20,7 @@ Sandbox Agent solves three problems:
 
 - **Coding agents need sandboxes:** You can't let AI execute arbitrary code on your production servers. Sandbox Agent runs inside the E2B sandbox and exposes HTTP/SSE.
 - **Every coding agent is different:** Claude Code, Codex, OpenCode, Cursor, Amp, and Pi each have proprietary APIs and event formats. Sandbox Agent provides one API, so swapping agents is a config change instead of a rewrite.
-- **Sessions are ephemeral:** Agent transcripts often die with the sandbox/process. Sandbox Agent emits a universal event schema so you can store, replay, and audit sessions outside the sandbox lifecycle.
+- **Sessions are ephemeral:** Agent transcripts often die with the sandbox/process. Sandbox Agent emits a universal event schema so you can store, replay, and audit sessions outside the sandbox lifecycle. See [session persistence](https://sandboxagent.dev/docs/session-persistence).
 
 ## Features
 

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -26,7 +26,7 @@ Sandbox Agent solves three problems:
 
 - **Universal Agent API**
 
-Claude Code, Codex, OpenCode, and Amp each have different APIs. We provide a single, unified interface to control them all.
+Claude Code, Codex, OpenCode, and Amp each have different APIs. Sandbox Agent exposes one HTTP API that works across all of them.
 
 - **Streaming Events**
 
@@ -68,7 +68,7 @@ OPENAI_API_KEY=your_openai_api_key
 # CODEX_API_KEY=your_codex_api_key
 # ANTHROPIC_API_KEY=your_anthropic_api_key
 
-# Optional: select a specific agent id
+# Optional: select which agent to run
 # AGENT=codex
 ```
 
@@ -88,6 +88,6 @@ KEEP_ALIVE=1 npm run start
 
 ## Notes
 
-- If `AGENT` is set, that exact agent ID is used.
+- If `AGENT` is set, that agent is used.
 - If `AGENT` is not set, the script defaults to `codex` when OpenAI/Codex keys exist, otherwise `claude` when Anthropic key exists.
 - API keys are available to processes running inside the sandbox.

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -1,6 +1,6 @@
 # Sandbox Agent SDK in E2B Sandbox (JavaScript)
 
-This example shows how to run [Sandbox Agent](https://github.com/rivet-dev/sandbox-agent) inside an E2B sandbox, then connect to it using the Sandbox Agent TypeScript SDK.
+This example shows how to run [Sandbox Agent](https://github.com/rivet-dev/sandbox-agent) inside an E2B sandbox, then connect to it using the [Sandbox Agent TypeScript SDK](https://sandboxagent.dev/docs/sdk-overview) (npm: [`sandbox-agent`](https://www.npmjs.com/package/sandbox-agent)).
 
 ## What this example does
 
@@ -89,3 +89,8 @@ KEEP_ALIVE=1 npm run start
 - If `AGENT` is set, that agent is used.
 - If `AGENT` is not set, the script defaults to `codex` when OpenAI/Codex keys exist, otherwise `claude` when Anthropic key exists.
 - API keys are available to processes running inside the sandbox.
+
+## References
+
+- [Sandbox Agent SDK docs](https://sandboxagent.dev/docs/sdk-overview)
+- [`sandbox-agent` npm package](https://www.npmjs.com/package/sandbox-agent)

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -24,27 +24,10 @@ Sandbox Agent solves three problems:
 
 ## Features
 
-- **Universal Agent API**
-
-Claude Code, Codex, OpenCode, and Amp each have different APIs. Sandbox Agent exposes one HTTP API that works across all of them.
-
-- **Streaming Events**
-
-Real-time SSE stream of everything the agent does. Persist to your storage, replay sessions, audit everything.
-
-- **Universal Schema**
-
-Standardized session schema that covers all features of all agents. Includes tool calls, permission requests, file edits, etc.
-
-- **Full Session Lifecycle Management**
-
-Create sessions, send messages, persist transcripts. Full session lifecycle management over HTTP.
-
-- **OpenCode Support**
-
-Experimental.
-
-Connect OpenCode CLI, SDK, or web UI to control agents through familiar OpenCode tooling.
+- **Universal Agent API** Claude Code, Codex, OpenCode, and Amp each have different APIs. Sandbox Agent exposes one HTTP API that works across all of them.
+- **Streaming Events** Real-time SSE stream of everything the agent does. Persist to your storage, replay sessions, audit everything.
+- **Universal Schema** Standardized session schema that covers all features of all agents. Includes tool calls, permission requests, file edits, etc.
+- **Full Session Lifecycle Management** Create sessions, send messages, persist transcripts. Full session lifecycle management over HTTP.
 
 ## Setup
 

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -22,6 +22,34 @@ Sandbox Agent solves three problems:
 - **Every coding agent is different:** Claude Code, Codex, OpenCode, Cursor, Amp, and Pi each have proprietary APIs and event formats. Sandbox Agent provides one API, so swapping agents is a config change (`SANDBOX_AGENT`) instead of a rewrite.
 - **Sessions are ephemeral:** Agent transcripts often die with the sandbox/process. Sandbox Agent emits a universal event schema so you can store, replay, and audit sessions outside the sandbox lifecycle.
 
+## Features
+
+- **Universal Agent API**
+
+Claude Code, Codex, OpenCode, and Amp each have different APIs. We provide a single, unified interface to control them all.
+
+- **Streaming Events**
+
+Real-time SSE stream of everything the agent does. Persist to your storage, replay sessions, audit everything.
+
+- **Universal Schema**
+
+Standardized session schema that covers all features of all agents. Includes tool calls, permission requests, file edits, etc.
+
+- **Runs Inside Any Sandbox**
+
+Run Sandbox Agent inside E2B, Daytona, Vercel Sandboxes, or Docker.
+
+- **Full Session Lifecycle Management**
+
+Create sessions, send messages, persist transcripts. Full session lifecycle management over HTTP.
+
+- **OpenCode Support**
+
+Experimental.
+
+Connect OpenCode CLI, SDK, or web UI to control agents through familiar OpenCode tooling.
+
 ## Setup
 
 1. Install dependencies:

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -6,13 +6,11 @@ Run [Sandbox Agent](https://github.com/rivet-dev/sandbox-agent) inside E2B, then
 
 Running coding agents remotely is hard: local-first SDK assumptions, SSH streaming/TTY issues, and agent-specific APIs.
 
-Sandbox Agent SDK gives you one API for:
+Sandbox Agent gives you a simple way to launch coding agents inside sandboxes and manage them over HTTP directly from your backend.
 
-- Session lifecycle
-- Prompt/send calls
-- Streaming events
-
-Sessions are ephemeral by default. For replay/audit, see [session persistence](https://sandboxagent.dev/docs/session-persistence).
+- **Single API, Multiple Agents** — Drive Claude Code, Codex, OpenCode, Cursor, Amp, and Pi from one unified interface with complete feature support — no need to build separate integrations for each.
+- **Standardized Event Schema** — Every agent outputs events in its own format. The universal session schema brings them all into a single, normalized structure that's easy to persist and replay.
+- **Two Ways to Deploy** — Use it as a self-contained HTTP server, or drop in the TypeScript SDK to embed it right inside your application.
 
 ## Setup
 
@@ -45,6 +43,7 @@ This starts up your Sandbox Agent and connects it to your E2B Sandbox. To run on
 ## References
 
 - [Sandbox Agent SDK docs](https://sandboxagent.dev/docs/sdk-overview)
+- [Sandbox Agent sessions and events](https://sandboxagent.dev/docs/agent-sessions).
 - [Sandbox Agent session persistence](https://sandboxagent.dev/docs/session-persistence)
 - [Sandbox Agent credentials](https://sandboxagent.dev/docs/credentials)
 - [E2B Sandbox Agent SDK guide](https://e2b.dev/docs/agents/sandbox-agent-sdk)

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -1,33 +1,18 @@
 # Sandbox Agent SDK in E2B Sandbox (JavaScript)
 
-This example shows how to run [Sandbox Agent](https://github.com/rivet-dev/sandbox-agent) inside an E2B sandbox, then connect to it using the [Sandbox Agent TypeScript SDK](https://sandboxagent.dev/docs/sdk-overview) (npm: [`sandbox-agent`](https://www.npmjs.com/package/sandbox-agent)).
+Run [Sandbox Agent](https://github.com/rivet-dev/sandbox-agent) inside E2B, then control it with the [Sandbox Agent SDK](https://sandboxagent.dev/docs/sdk-overview) (npm: [`sandbox-agent`](https://www.npmjs.com/package/sandbox-agent)).
 
-## What this example does
+## Why use Sandbox Agent SDK
 
-1. Creates an E2B sandbox.
-2. Installs Sandbox Agent CLI in the sandbox.
-3. Installs a coding agent (for example `codex` or `claude`).
-4. Starts `sandbox-agent server` in the sandbox.
-5. Connects with `SandboxAgent.connect(...)` and creates a session.
+Running coding agents remotely is hard: local-first SDK assumptions, SSH streaming/TTY issues, and agent-specific APIs.
 
-## Why use Sandbox Agent SDK?
+Sandbox Agent SDK gives you one API for:
 
-Running coding agents remotely is hard. Existing SDKs assume local execution, SSH breaks streaming and interactive workflows, and every coding agent has a different API.
+- Session lifecycle
+- Prompt/send calls
+- Streaming events
 
-Building this from scratch usually means rewriting everything for each coding agent.
-
-Sandbox Agent solves three problems:
-
-- **Coding agents need sandboxes:** You can't let AI execute arbitrary code on your production servers. Sandbox Agent runs inside the E2B sandbox and exposes HTTP/SSE.
-- **Every coding agent is different:** Claude Code, Codex, OpenCode, Cursor, Amp, and Pi each have proprietary APIs and event formats. Sandbox Agent provides one API, so swapping agents is a config change instead of a rewrite.
-- **Sessions are ephemeral:** Agent transcripts often die with the sandbox/process. Sandbox Agent emits a universal event schema so you can store, replay, and audit sessions outside the sandbox lifecycle. See [session persistence](https://sandboxagent.dev/docs/session-persistence).
-
-## Features
-
-- **Universal Agent API** Claude Code, Codex, OpenCode, and Amp each have different APIs. Sandbox Agent exposes one HTTP API that works across all of them.
-- **Streaming Events** Real-time SSE stream of everything the agent does. Persist to your storage, replay sessions, audit everything.
-- **Universal Schema** Standardized session schema that covers all features of all agents. Includes tool calls, permission requests, file edits, etc.
-- **Full Session Lifecycle Management** Create sessions, send messages, persist transcripts. Full session lifecycle management over HTTP.
+Sessions are ephemeral by default. For replay/audit, see [session persistence](https://sandboxagent.dev/docs/session-persistence).
 
 ## Setup
 
@@ -37,43 +22,41 @@ Sandbox Agent solves three problems:
 npm install
 ```
 
-2. Create a `.env` file:
+2. Create `.env`:
 
 ```bash
 E2B_API_KEY=your_e2b_api_key
 
-# Provide at least one provider key
+# At least one provider key
 OPENAI_API_KEY=your_openai_api_key
 # CODEX_API_KEY=your_codex_api_key
 # ANTHROPIC_API_KEY=your_anthropic_api_key
 
-# Other agents may require additional credentials. Set any extra provider keys as environment variables.
-
-# Optional: select which agent to run
-# AGENT=codex
+# Optional: use a custom E2B template/snapshot alias
+# E2B_TEMPLATE=base
 ```
 
-3. Run the example:
+Provider credential options for other agents: [Sandbox Agent credentials docs](https://sandboxagent.dev/docs/credentials).
+
+3. Run:
 
 ```bash
 npm run start
 ```
 
-The script prints an Inspector URL once the server and session are ready, then exits after cleanup.
+## What the script does
 
-To keep the sandbox running so you can open the Inspector URL, run:
+1. Creates an E2B sandbox (from `E2B_TEMPLATE`, default `base`).
+2. Installs `sandbox-agent` CLI and installs an agent.
+3. Starts `sandbox-agent --no-token server`.
+4. Connects with `SandboxAgent.connect(...)` and creates a session.
+5. Prints an Inspector URL.
 
-```bash
-KEEP_ALIVE=1 npm run start
-```
-
-## Notes
-
-- If `AGENT` is set, that agent is used.
-- If `AGENT` is not set, the script defaults to `codex` when OpenAI/Codex keys exist, otherwise `claude` when Anthropic key exists.
-- API keys are available to processes running inside the sandbox.
+To run one prompt and stream events, uncomment the block in `src/index.ts`.
 
 ## References
 
 - [Sandbox Agent SDK docs](https://sandboxagent.dev/docs/sdk-overview)
-- [`sandbox-agent` npm package](https://www.npmjs.com/package/sandbox-agent)
+- [Sandbox Agent session persistence](https://sandboxagent.dev/docs/session-persistence)
+- [Sandbox Agent credentials](https://sandboxagent.dev/docs/credentials)
+- [E2B AMP guide](https://e2b.dev/docs/agents/amp)

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -29,7 +29,6 @@ E2B_API_KEY=your_e2b_api_key
 
 # At least one provider key
 OPENAI_API_KEY=your_openai_api_key
-# CODEX_API_KEY=your_codex_api_key
 # ANTHROPIC_API_KEY=your_anthropic_api_key
 ```
 

--- a/examples/sandbox-agent-sdk-js/README.md
+++ b/examples/sandbox-agent-sdk-js/README.md
@@ -6,7 +6,7 @@ This example shows how to run [Sandbox Agent](https://github.com/rivet-dev/sandb
 
 1. Creates an E2B sandbox.
 2. Installs Sandbox Agent CLI in the sandbox.
-3. Installs a coding agent (`codex`, `claude`, or any `SANDBOX_AGENT` value).
+3. Installs a coding agent (for example `codex` or `claude`).
 4. Starts `sandbox-agent server` in the sandbox.
 5. Connects with `SandboxAgent.connect(...)` and creates a session.
 
@@ -19,7 +19,7 @@ Building this from scratch usually means rewriting everything for each coding ag
 Sandbox Agent solves three problems:
 
 - **Coding agents need sandboxes:** You can't let AI execute arbitrary code on your production servers. Sandbox Agent runs inside the E2B sandbox and exposes HTTP/SSE.
-- **Every coding agent is different:** Claude Code, Codex, OpenCode, Cursor, Amp, and Pi each have proprietary APIs and event formats. Sandbox Agent provides one API, so swapping agents is a config change (`SANDBOX_AGENT`) instead of a rewrite.
+- **Every coding agent is different:** Claude Code, Codex, OpenCode, Cursor, Amp, and Pi each have proprietary APIs and event formats. Sandbox Agent provides one API, so swapping agents is a config change instead of a rewrite.
 - **Sessions are ephemeral:** Agent transcripts often die with the sandbox/process. Sandbox Agent emits a universal event schema so you can store, replay, and audit sessions outside the sandbox lifecycle.
 
 ## Features
@@ -63,13 +63,13 @@ npm install
 ```bash
 E2B_API_KEY=your_e2b_api_key
 
-# Provide at least one provider key, unless SANDBOX_AGENT points to a compatible preinstalled agent
+# Provide at least one provider key
 OPENAI_API_KEY=your_openai_api_key
 # CODEX_API_KEY=your_codex_api_key
 # ANTHROPIC_API_KEY=your_anthropic_api_key
 
-# Optional: any specific agent id
-# SANDBOX_AGENT=codex
+# Optional: select a specific agent id
+# AGENT=codex
 ```
 
 3. Run the example:
@@ -88,6 +88,6 @@ KEEP_ALIVE=1 npm run start
 
 ## Notes
 
-- If `SANDBOX_AGENT` is set, that exact agent ID is used.
-- If `SANDBOX_AGENT` is not set, the script defaults to `codex` when OpenAI/Codex keys exist, otherwise `claude` when Anthropic key exists.
+- If `AGENT` is set, that exact agent ID is used.
+- If `AGENT` is not set, the script defaults to `codex` when OpenAI/Codex keys exist, otherwise `claude` when Anthropic key exists.
 - API keys are available to processes running inside the sandbox.

--- a/examples/sandbox-agent-sdk-js/package-lock.json
+++ b/examples/sandbox-agent-sdk-js/package-lock.json
@@ -1,0 +1,1065 @@
+{
+  "name": "sandbox-agent-sdk-js",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sandbox-agent-sdk-js",
+      "version": "1.0.0",
+      "dependencies": {
+        "dotenv": "^16.5.0",
+        "e2b": "^2.3.4",
+        "sandbox-agent": "latest",
+        "tsx": "^4.20.3"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.14.1.tgz",
+      "integrity": "sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
+      "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0-rc.3.tgz",
+      "integrity": "sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0",
+        "@connectrpc/connect": "2.0.0-rc.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sandbox-agent/cli": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli/-/cli-0.2.0.tgz",
+      "integrity": "sha512-kTZyybllHki1cCiSUt20udzlrN4Z94rnRMDSquebOaR3AkkJQQVe7oXvapeDezujIN+C4H7TUpCFVf+40DgeIg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@sandbox-agent/cli-shared": "0.2.0"
+      },
+      "bin": {
+        "sandbox-agent": "bin/sandbox-agent"
+      },
+      "optionalDependencies": {
+        "@sandbox-agent/cli-darwin-arm64": "0.2.0",
+        "@sandbox-agent/cli-darwin-x64": "0.2.0",
+        "@sandbox-agent/cli-linux-arm64": "0.2.0",
+        "@sandbox-agent/cli-linux-x64": "0.2.0",
+        "@sandbox-agent/cli-win32-x64": "0.2.0"
+      }
+    },
+    "node_modules/@sandbox-agent/cli-darwin-arm64": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-darwin-arm64/-/cli-darwin-arm64-0.2.0.tgz",
+      "integrity": "sha512-DQ8nmqnHYwZvtVh1q4Tuy1qlzWiYYwg/7W8Jc2nwGobIrxVl3atMC0uZ22yx2OlxP5VRu6UkPJUuhB3LMy59NA==",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@sandbox-agent/cli-darwin-x64": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-darwin-x64/-/cli-darwin-x64-0.2.0.tgz",
+      "integrity": "sha512-elHLfqNY4So1WXXWIKYThLiD/V4RZcvK9w0DQ4LGFQc87KDvHsaucN1V3tY2O7IW+A5URvvLENkm/UBkzpiFzg==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@sandbox-agent/cli-linux-arm64": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-linux-arm64/-/cli-linux-arm64-0.2.0.tgz",
+      "integrity": "sha512-JrYAS1tODC0i4xkWyv6qQWZ7Ejrx8scQrTemYwzRjTFC7ms77/6eVJp9BCN0Oml5IXK8mFHrzGmEqdtyPcI53w==",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@sandbox-agent/cli-linux-x64": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-linux-x64/-/cli-linux-x64-0.2.0.tgz",
+      "integrity": "sha512-yzJ4gK1gWB7geNdybZS/SVuwn4UvhBDzodD6F9hhwH8HvGlWOkwiBGrkC+EfKVKToewHztaKO2wMKoI737VkIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@sandbox-agent/cli-shared": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-shared/-/cli-shared-0.2.0.tgz",
+      "integrity": "sha512-gME/yVdeNlkNQRYfJOnkELziXnw++CzzrqCMWoAXf1c5cJYYEZIAMQ4y/WRIQgc/1BV8EjnHWxLJxgyqOF1zRw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@sandbox-agent/cli-win32-x64": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-win32-x64/-/cli-win32-x64-0.2.0.tgz",
+      "integrity": "sha512-Zdl/RtSX31LcGgu8/36VyKx/kEFoutjEUG79vnaywEvaCAk0LyECBEHHKGHnIZpBiHkaNfK3rapY6rKPAquhJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/acp-http-client": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/acp-http-client/-/acp-http-client-0.1.0.tgz",
+      "integrity": "sha512-EI0HH0lcr+Cypten2Otzfuo+406EVGUWR6pWfo3TVVHqbSPBUIAtVjF8HCQycJWpkKlt1mgVXmC8kRaidEQbeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "^0.14.1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
+      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
+      "license": "MIT",
+      "dependencies": {
+        "jackspeak": "^4.2.3"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dockerfile-ast": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.1.tgz",
+      "integrity": "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/e2b": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/e2b/-/e2b-2.12.1.tgz",
+      "integrity": "sha512-qKYwS0VSZqvtWAT4OrCtOwRhhMlcd359zyFRGAZZ1wpYHHjr9zR872UCoDb/d5jFVUsREcUgktURc47XxfznPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.6.2",
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-web": "2.0.0-rc.3",
+        "chalk": "^5.3.0",
+        "compare-versions": "^6.1.0",
+        "dockerfile-ast": "^0.7.1",
+        "glob": "^11.1.0",
+        "openapi-fetch": "^0.14.1",
+        "platform": "^1.3.6",
+        "tar": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
+      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/openapi-fetch": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz",
+      "integrity": "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/sandbox-agent": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sandbox-agent/-/sandbox-agent-0.2.0.tgz",
+      "integrity": "sha512-3mwFbnu+R/SMIRHIQWNFb/G/CC1+b3CjpN7d9qEor8V2AOPQ44hvb75+CuT0H2ZZPwuUsxqIF6lPGx2xrskINw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sandbox-agent/cli-shared": "0.2.0",
+        "acp-http-client": "0.1.0"
+      },
+      "optionalDependencies": {
+        "@sandbox-agent/cli": "0.2.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/sandbox-agent-sdk-js/package-lock.json
+++ b/examples/sandbox-agent-sdk-js/package-lock.json
@@ -8,16 +8,20 @@
       "name": "sandbox-agent-sdk-js",
       "version": "1.0.0",
       "dependencies": {
+        "@e2b/code-interpreter": "^2.4.0",
         "dotenv": "^16.5.0",
         "e2b": "^2.3.4",
-        "sandbox-agent": "latest",
-        "tsx": "^4.20.3"
+        "sandbox-agent": "latest"
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "tsx": "^4.21.0"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.14.1.tgz",
-      "integrity": "sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.16.1.tgz",
+      "integrity": "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -48,6 +52,18 @@
         "@connectrpc/connect": "2.0.0-rc.3"
       }
     },
+    "node_modules/@e2b/code-interpreter": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@e2b/code-interpreter/-/code-interpreter-2.4.0.tgz",
+      "integrity": "sha512-6yLi0I2/FBhB6beqtuiFMTajB3PHQw+5+apuI3QdEv1Rx8e2Xp0h37SL0Y6tuVJQ2Frp7P3wWT77Wvy6l6OHPA==",
+      "license": "MIT",
+      "dependencies": {
+        "e2b": "^2.8.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
@@ -55,6 +71,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71,6 +88,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -87,6 +105,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -103,6 +122,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -119,6 +139,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -135,6 +156,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -151,6 +173,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -167,6 +190,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -183,6 +207,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -199,6 +224,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -215,6 +241,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -231,6 +258,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -247,6 +275,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -263,6 +292,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -279,6 +309,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -295,6 +326,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -311,6 +343,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -327,6 +360,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -343,6 +377,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -359,6 +394,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -375,6 +411,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -391,6 +428,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -407,6 +445,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -423,6 +462,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -439,6 +479,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -455,6 +496,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -486,29 +528,29 @@
       }
     },
     "node_modules/@sandbox-agent/cli": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli/-/cli-0.2.0.tgz",
-      "integrity": "sha512-kTZyybllHki1cCiSUt20udzlrN4Z94rnRMDSquebOaR3AkkJQQVe7oXvapeDezujIN+C4H7TUpCFVf+40DgeIg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli/-/cli-0.4.0.tgz",
+      "integrity": "sha512-1xoLnr0ZAEgvGtVpBGkyGuACwI3Th4D2i218K1pr+YlBRclsps7TjRjddkEuTXZgQj4wjQ4uUjlDsvUBhvHMQQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@sandbox-agent/cli-shared": "0.2.0"
+        "@sandbox-agent/cli-shared": "0.4.0"
       },
       "bin": {
         "sandbox-agent": "bin/sandbox-agent"
       },
       "optionalDependencies": {
-        "@sandbox-agent/cli-darwin-arm64": "0.2.0",
-        "@sandbox-agent/cli-darwin-x64": "0.2.0",
-        "@sandbox-agent/cli-linux-arm64": "0.2.0",
-        "@sandbox-agent/cli-linux-x64": "0.2.0",
-        "@sandbox-agent/cli-win32-x64": "0.2.0"
+        "@sandbox-agent/cli-darwin-arm64": "0.4.0",
+        "@sandbox-agent/cli-darwin-x64": "0.4.0",
+        "@sandbox-agent/cli-linux-arm64": "0.4.0",
+        "@sandbox-agent/cli-linux-x64": "0.4.0",
+        "@sandbox-agent/cli-win32-x64": "0.4.0"
       }
     },
     "node_modules/@sandbox-agent/cli-darwin-arm64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-darwin-arm64/-/cli-darwin-arm64-0.2.0.tgz",
-      "integrity": "sha512-DQ8nmqnHYwZvtVh1q4Tuy1qlzWiYYwg/7W8Jc2nwGobIrxVl3atMC0uZ22yx2OlxP5VRu6UkPJUuhB3LMy59NA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-darwin-arm64/-/cli-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-AaMd2h2OPG5k5DFxfc7jNtmYu3S1PS1BZjXGbXZ2NfAScwVCSeBuN0vvmSxP23CqPrEpf1m7PnruFrFh67Khhw==",
       "cpu": [
         "arm64"
       ],
@@ -520,9 +562,9 @@
       ]
     },
     "node_modules/@sandbox-agent/cli-darwin-x64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-darwin-x64/-/cli-darwin-x64-0.2.0.tgz",
-      "integrity": "sha512-elHLfqNY4So1WXXWIKYThLiD/V4RZcvK9w0DQ4LGFQc87KDvHsaucN1V3tY2O7IW+A5URvvLENkm/UBkzpiFzg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-darwin-x64/-/cli-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-dnr9xpiVXGbOqolukyLy1NNV+1w97yFh2zJL6TRuXg86eQbHSQRXVm/PqRMlr8KyVYdaLPQJeR8s4ofGvoa6Rg==",
       "cpu": [
         "x64"
       ],
@@ -534,9 +576,9 @@
       ]
     },
     "node_modules/@sandbox-agent/cli-linux-arm64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-linux-arm64/-/cli-linux-arm64-0.2.0.tgz",
-      "integrity": "sha512-JrYAS1tODC0i4xkWyv6qQWZ7Ejrx8scQrTemYwzRjTFC7ms77/6eVJp9BCN0Oml5IXK8mFHrzGmEqdtyPcI53w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-linux-arm64/-/cli-linux-arm64-0.4.0.tgz",
+      "integrity": "sha512-217tEQU/47aNG7BFC27apZ51jEZgLfU7J3i5R52b+w3aI3khDyfJ/UHvkd1tsMztp59UjZTxwuY7xXSRkaTSGQ==",
       "cpu": [
         "arm64"
       ],
@@ -548,9 +590,9 @@
       ]
     },
     "node_modules/@sandbox-agent/cli-linux-x64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-linux-x64/-/cli-linux-x64-0.2.0.tgz",
-      "integrity": "sha512-yzJ4gK1gWB7geNdybZS/SVuwn4UvhBDzodD6F9hhwH8HvGlWOkwiBGrkC+EfKVKToewHztaKO2wMKoI737VkIQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-linux-x64/-/cli-linux-x64-0.4.0.tgz",
+      "integrity": "sha512-j39uNei4/dnX3Oy3hwqzrndZwPRE2SraahhfCGycymlFqN/p4Xii004QQ0WOP/vibQSGq+lPYR3faSevmjMZig==",
       "cpu": [
         "x64"
       ],
@@ -562,15 +604,15 @@
       ]
     },
     "node_modules/@sandbox-agent/cli-shared": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-shared/-/cli-shared-0.2.0.tgz",
-      "integrity": "sha512-gME/yVdeNlkNQRYfJOnkELziXnw++CzzrqCMWoAXf1c5cJYYEZIAMQ4y/WRIQgc/1BV8EjnHWxLJxgyqOF1zRw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-shared/-/cli-shared-0.4.0.tgz",
+      "integrity": "sha512-hSNNIZJlnGlL0yVfp+d1N97qimO0dz6QB24vmfO4pviiBICcoIcoxnOv9l3aj8Z4nT8A3WTy/6cypYHUpoLxkQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@sandbox-agent/cli-win32-x64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-win32-x64/-/cli-win32-x64-0.2.0.tgz",
-      "integrity": "sha512-Zdl/RtSX31LcGgu8/36VyKx/kEFoutjEUG79vnaywEvaCAk0LyECBEHHKGHnIZpBiHkaNfK3rapY6rKPAquhJQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-win32-x64/-/cli-win32-x64-0.4.0.tgz",
+      "integrity": "sha512-8OyIgsr/jMzMhAj5Fyz9VHj0ZEkGkaxAAELg4U0y5632Vkae8jcJRZyZ8bv6fBJp3zG2sgj47UJFfmHHh4pfMg==",
       "cpu": [
         "x64"
       ],
@@ -580,13 +622,23 @@
         "win32"
       ]
     },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/acp-http-client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/acp-http-client/-/acp-http-client-0.1.0.tgz",
-      "integrity": "sha512-EI0HH0lcr+Cypten2Otzfuo+406EVGUWR6pWfo3TVVHqbSPBUIAtVjF8HCQycJWpkKlt1mgVXmC8kRaidEQbeA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/acp-http-client/-/acp-http-client-0.4.0.tgz",
+      "integrity": "sha512-RxXaX7hLyxYVpOwmzwc6FIud7icdcPfYqTsVoqJFkI/G5qE7feiac4jSB5SC6P6awy4FMHpFogYEp92vzZTKJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.14.1"
+        "@agentclientprotocol/sdk": "^0.16.1"
       }
     },
     "node_modules/balanced-match": {
@@ -704,6 +756,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -761,6 +814,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -775,6 +829,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -929,22 +984,59 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/sandbox-agent": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sandbox-agent/-/sandbox-agent-0.2.0.tgz",
-      "integrity": "sha512-3mwFbnu+R/SMIRHIQWNFb/G/CC1+b3CjpN7d9qEor8V2AOPQ44hvb75+CuT0H2ZZPwuUsxqIF6lPGx2xrskINw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/sandbox-agent/-/sandbox-agent-0.4.0.tgz",
+      "integrity": "sha512-vm/+LB/3dtGVjZkSI5w3fsCrJwF7mQr8f0FE7vSAy1elp1qgaHtpCRqBeCVeYv7zGAtjuXZzO42/kZbFZX/h+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@sandbox-agent/cli-shared": "0.2.0",
-        "acp-http-client": "0.1.0"
+        "@sandbox-agent/cli-shared": "0.4.0",
+        "acp-http-client": "0.4.0"
       },
       "optionalDependencies": {
-        "@sandbox-agent/cli": "0.2.0"
+        "@sandbox-agent/cli": "0.4.0"
+      },
+      "peerDependencies": {
+        "@cloudflare/sandbox": ">=0.1.0",
+        "@daytonaio/sdk": ">=0.12.0",
+        "@e2b/code-interpreter": ">=1.0.0",
+        "@vercel/sandbox": ">=0.1.0",
+        "computesdk": ">=0.1.0",
+        "dockerode": ">=4.0.0",
+        "get-port": ">=7.0.0",
+        "modal": ">=0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/sandbox": {
+          "optional": true
+        },
+        "@daytonaio/sdk": {
+          "optional": true
+        },
+        "@e2b/code-interpreter": {
+          "optional": true
+        },
+        "@vercel/sandbox": {
+          "optional": true
+        },
+        "computesdk": {
+          "optional": true
+        },
+        "dockerode": {
+          "optional": true
+        },
+        "get-port": {
+          "optional": true
+        },
+        "modal": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {
@@ -1000,6 +1092,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -1014,6 +1107,13 @@
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",

--- a/examples/sandbox-agent-sdk-js/package-lock.json
+++ b/examples/sandbox-agent-sdk-js/package-lock.json
@@ -20,8 +20,6 @@
     },
     "node_modules/@agentclientprotocol/sdk": {
       "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.16.1.tgz",
-      "integrity": "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -29,14 +27,10 @@
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
-      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@connectrpc/connect": {
       "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
-      "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
@@ -44,8 +38,6 @@
     },
     "node_modules/@connectrpc/connect-web": {
       "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0-rc.3.tgz",
-      "integrity": "sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
@@ -54,8 +46,6 @@
     },
     "node_modules/@e2b/code-interpreter": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@e2b/code-interpreter/-/code-interpreter-2.4.0.tgz",
-      "integrity": "sha512-6yLi0I2/FBhB6beqtuiFMTajB3PHQw+5+apuI3QdEv1Rx8e2Xp0h37SL0Y6tuVJQ2Frp7P3wWT77Wvy6l6OHPA==",
       "license": "MIT",
       "dependencies": {
         "e2b": "^2.8.4"
@@ -64,78 +54,8 @@
         "node": ">=20"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
       "cpu": [
         "arm64"
       ],
@@ -144,363 +64,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -508,8 +71,6 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -517,8 +78,6 @@
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -528,29 +87,25 @@
       }
     },
     "node_modules/@sandbox-agent/cli": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli/-/cli-0.4.0.tgz",
-      "integrity": "sha512-1xoLnr0ZAEgvGtVpBGkyGuACwI3Th4D2i218K1pr+YlBRclsps7TjRjddkEuTXZgQj4wjQ4uUjlDsvUBhvHMQQ==",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@sandbox-agent/cli-shared": "0.4.0"
+        "@sandbox-agent/cli-shared": "0.4.1"
       },
       "bin": {
         "sandbox-agent": "bin/sandbox-agent"
       },
       "optionalDependencies": {
-        "@sandbox-agent/cli-darwin-arm64": "0.4.0",
-        "@sandbox-agent/cli-darwin-x64": "0.4.0",
-        "@sandbox-agent/cli-linux-arm64": "0.4.0",
-        "@sandbox-agent/cli-linux-x64": "0.4.0",
-        "@sandbox-agent/cli-win32-x64": "0.4.0"
+        "@sandbox-agent/cli-darwin-arm64": "0.4.1",
+        "@sandbox-agent/cli-darwin-x64": "0.4.1",
+        "@sandbox-agent/cli-linux-arm64": "0.4.1",
+        "@sandbox-agent/cli-linux-x64": "0.4.1",
+        "@sandbox-agent/cli-win32-x64": "0.4.1"
       }
     },
     "node_modules/@sandbox-agent/cli-darwin-arm64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-darwin-arm64/-/cli-darwin-arm64-0.4.0.tgz",
-      "integrity": "sha512-AaMd2h2OPG5k5DFxfc7jNtmYu3S1PS1BZjXGbXZ2NfAScwVCSeBuN0vvmSxP23CqPrEpf1m7PnruFrFh67Khhw==",
+      "version": "0.4.1",
       "cpu": [
         "arm64"
       ],
@@ -559,73 +114,14 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@sandbox-agent/cli-darwin-x64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-darwin-x64/-/cli-darwin-x64-0.4.0.tgz",
-      "integrity": "sha512-dnr9xpiVXGbOqolukyLy1NNV+1w97yFh2zJL6TRuXg86eQbHSQRXVm/PqRMlr8KyVYdaLPQJeR8s4ofGvoa6Rg==",
-      "cpu": [
-        "x64"
-      ],
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@sandbox-agent/cli-linux-arm64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-linux-arm64/-/cli-linux-arm64-0.4.0.tgz",
-      "integrity": "sha512-217tEQU/47aNG7BFC27apZ51jEZgLfU7J3i5R52b+w3aI3khDyfJ/UHvkd1tsMztp59UjZTxwuY7xXSRkaTSGQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@sandbox-agent/cli-linux-x64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-linux-x64/-/cli-linux-x64-0.4.0.tgz",
-      "integrity": "sha512-j39uNei4/dnX3Oy3hwqzrndZwPRE2SraahhfCGycymlFqN/p4Xii004QQ0WOP/vibQSGq+lPYR3faSevmjMZig==",
-      "cpu": [
-        "x64"
-      ],
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
       ]
     },
     "node_modules/@sandbox-agent/cli-shared": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-shared/-/cli-shared-0.4.0.tgz",
-      "integrity": "sha512-hSNNIZJlnGlL0yVfp+d1N97qimO0dz6QB24vmfO4pviiBICcoIcoxnOv9l3aj8Z4nT8A3WTy/6cypYHUpoLxkQ==",
+      "version": "0.4.1",
       "license": "Apache-2.0"
-    },
-    "node_modules/@sandbox-agent/cli-win32-x64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@sandbox-agent/cli-win32-x64/-/cli-win32-x64-0.4.0.tgz",
-      "integrity": "sha512-8OyIgsr/jMzMhAj5Fyz9VHj0ZEkGkaxAAELg4U0y5632Vkae8jcJRZyZ8bv6fBJp3zG2sgj47UJFfmHHh4pfMg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -633,9 +129,7 @@
       }
     },
     "node_modules/acp-http-client": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/acp-http-client/-/acp-http-client-0.4.0.tgz",
-      "integrity": "sha512-RxXaX7hLyxYVpOwmzwc6FIud7icdcPfYqTsVoqJFkI/G5qE7feiac4jSB5SC6P6awy4FMHpFogYEp92vzZTKJA==",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.16.1"
@@ -643,8 +137,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
-      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
       "license": "MIT",
       "dependencies": {
         "jackspeak": "^4.2.3"
@@ -655,8 +147,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
-      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -667,8 +157,6 @@
     },
     "node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -679,8 +167,6 @@
     },
     "node_modules/chownr": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -688,14 +174,10 @@
     },
     "node_modules/compare-versions": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
-      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -708,8 +190,6 @@
     },
     "node_modules/dockerfile-ast": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.1.tgz",
-      "integrity": "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==",
       "license": "MIT",
       "dependencies": {
         "vscode-languageserver-textdocument": "^1.0.8",
@@ -721,8 +201,6 @@
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -733,8 +211,6 @@
     },
     "node_modules/e2b": {
       "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/e2b/-/e2b-2.12.1.tgz",
-      "integrity": "sha512-qKYwS0VSZqvtWAT4OrCtOwRhhMlcd359zyFRGAZZ1wpYHHjr9zR872UCoDb/d5jFVUsREcUgktURc47XxfznPg==",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.6.2",
@@ -754,8 +230,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -796,8 +270,6 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -812,10 +284,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -827,8 +296,6 @@
     },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -840,9 +307,6 @@
     },
     "node_modules/glob": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
@@ -864,14 +328,10 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^9.0.0"
@@ -885,8 +345,6 @@
     },
     "node_modules/lru-cache": {
       "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -894,8 +352,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
-      "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -909,8 +365,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -918,8 +372,6 @@
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -930,8 +382,6 @@
     },
     "node_modules/openapi-fetch": {
       "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz",
-      "integrity": "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==",
       "license": "MIT",
       "dependencies": {
         "openapi-typescript-helpers": "^0.0.15"
@@ -939,20 +389,14 @@
     },
     "node_modules/openapi-typescript-helpers": {
       "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
-      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
       "license": "MIT"
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -960,8 +404,6 @@
     },
     "node_modules/path-scurry": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -976,14 +418,10 @@
     },
     "node_modules/platform": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -991,21 +429,22 @@
       }
     },
     "node_modules/sandbox-agent": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/sandbox-agent/-/sandbox-agent-0.4.0.tgz",
-      "integrity": "sha512-vm/+LB/3dtGVjZkSI5w3fsCrJwF7mQr8f0FE7vSAy1elp1qgaHtpCRqBeCVeYv7zGAtjuXZzO42/kZbFZX/h+A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/sandbox-agent/-/sandbox-agent-0.4.1.tgz",
+      "integrity": "sha512-xdjnStOvHMDf5O2/GyMtgGPAb/d3LxJ8T5bCtOun6jxh0LzkWRMmgxGRu2pxEPVZf3Lg9LQg6RUfPTJnGECAjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@sandbox-agent/cli-shared": "0.4.0",
-        "acp-http-client": "0.4.0"
+        "@sandbox-agent/cli-shared": "0.4.1",
+        "acp-http-client": "0.4.1"
       },
       "optionalDependencies": {
-        "@sandbox-agent/cli": "0.4.0"
+        "@sandbox-agent/cli": "0.4.1"
       },
       "peerDependencies": {
         "@cloudflare/sandbox": ">=0.1.0",
         "@daytonaio/sdk": ">=0.12.0",
         "@e2b/code-interpreter": ">=1.0.0",
+        "@fly/sprites": ">=0.0.1",
         "@vercel/sandbox": ">=0.1.0",
         "computesdk": ">=0.1.0",
         "dockerode": ">=4.0.0",
@@ -1020,6 +459,9 @@
           "optional": true
         },
         "@e2b/code-interpreter": {
+          "optional": true
+        },
+        "@fly/sprites": {
           "optional": true
         },
         "@vercel/sandbox": {
@@ -1041,8 +483,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -1053,8 +493,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1062,8 +500,6 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -1074,8 +510,6 @@
     },
     "node_modules/tar": {
       "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -1090,8 +524,6 @@
     },
     "node_modules/tsx": {
       "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1110,27 +542,19 @@
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -1144,8 +568,6 @@
     },
     "node_modules/yallist": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -1153,8 +575,6 @@
     },
     "node_modules/zod": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/examples/sandbox-agent-sdk-js/package.json
+++ b/examples/sandbox-agent-sdk-js/package.json
@@ -7,9 +7,13 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
+    "@e2b/code-interpreter": "^2.4.0",
     "dotenv": "^16.5.0",
     "e2b": "^2.3.4",
-    "sandbox-agent": "latest",
-    "tsx": "^4.20.3"
+    "sandbox-agent": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsx": "^4.21.0"
   }
 }

--- a/examples/sandbox-agent-sdk-js/package.json
+++ b/examples/sandbox-agent-sdk-js/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sandbox-agent-sdk-js",
+  "version": "1.0.0",
+  "description": "Run Sandbox Agent inside an E2B sandbox and control it using the Sandbox Agent TypeScript SDK.",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "dotenv": "^16.5.0",
+    "e2b": "^2.3.4",
+    "sandbox-agent": "latest",
+    "tsx": "^4.20.3"
+  }
+}

--- a/examples/sandbox-agent-sdk-js/package.json
+++ b/examples/sandbox-agent-sdk-js/package.json
@@ -10,7 +10,7 @@
     "@e2b/code-interpreter": "^2.4.0",
     "dotenv": "^16.5.0",
     "e2b": "^2.3.4",
-    "sandbox-agent": "latest"
+    "sandbox-agent": "^0.4.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -3,6 +3,7 @@ import { Sandbox } from 'e2b'
 import { SandboxAgent } from 'sandbox-agent'
 
 const SERVER_TOKEN = 'sandbox-agent-e2b-demo-token'
+const KEEP_ALIVE = process.env.KEEP_ALIVE === '1'
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -61,6 +62,34 @@ let client: SandboxAgent | undefined
 try {
   console.log(`E2B sandbox ID: ${sandbox.sandboxId}`)
 
+  if (KEEP_ALIVE) {
+    // If the runtime closes a long-lived connection (SSE/stream), don't crash and
+    // implicitly delete the sandbox. In KEEP_ALIVE mode we want the sandbox to stay up.
+    process.on('unhandledRejection', (error) => {
+      console.error('Unhandled rejection:', error)
+    })
+    process.on('uncaughtException', (error) => {
+      console.error('Uncaught exception:', error)
+    })
+
+    const cleanupAndExit = async (code: number) => {
+      try {
+        if (client) await client.dispose()
+      } catch {
+        // ignore
+      }
+      try {
+        await sandbox.kill()
+      } catch (error) {
+        console.error('Failed to kill sandbox:', error)
+      }
+      process.exit(code)
+    }
+
+    process.once('SIGINT', () => void cleanupAndExit(0))
+    process.once('SIGTERM', () => void cleanupAndExit(0))
+  }
+
   const run = async (command: string) => {
     const result = await sandbox.commands.run(command)
     if (result.exitCode !== 0) {
@@ -100,6 +129,10 @@ try {
   // await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
 
   if (process.env.KEEP_ALIVE === '1') {
+    // Close the SDK transport (streams/SSE) but keep the sandbox + server running.
+    // The Inspector UI talks directly to the server URL.
+    await client.dispose()
+    client = undefined
     console.log('KEEP_ALIVE=1 set. Press Ctrl+C to stop and delete the sandbox.')
     // Keep process alive until interrupted so you can open the Inspector URL.
     while (true) {

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -1,77 +1,45 @@
-import 'dotenv/config'
-import { setTimeout as delay } from 'node:timers/promises'
-import { Sandbox } from 'e2b'
-import { SandboxAgent } from 'sandbox-agent'
+import 'dotenv/config';
+import { SandboxAgent } from 'sandbox-agent';
+import { e2b } from 'sandbox-agent/e2b';
 
-const SERVER_PORT = 3000
-const SANDBOX_AGENT_CLI_VERSION = '0.2.x'
-const E2B_TEMPLATE = process.env.E2B_TEMPLATE?.trim() || 'base'
+async function main() {
+	const envs: Record<string, string> = {};
+	if (process.env.ANTHROPIC_API_KEY) envs.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+	if (process.env.OPENAI_API_KEY) envs.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+	if (process.env.CODEX_API_KEY) envs.CODEX_API_KEY = process.env.CODEX_API_KEY;
+	if (!envs.CODEX_API_KEY && envs.OPENAI_API_KEY) envs.CODEX_API_KEY = envs.OPENAI_API_KEY;
+	if (!envs.OPENAI_API_KEY && !envs.CODEX_API_KEY && !envs.ANTHROPIC_API_KEY) {
+		throw new Error('Set OPENAI_API_KEY/CODEX_API_KEY or ANTHROPIC_API_KEY');
+	}
 
-async function waitForHealth(baseUrl: string): Promise<void> {
-  const deadline = Date.now() + 120_000
-  while (Date.now() < deadline) {
-    const [attempt] = await Promise.allSettled([
-      fetch(`${baseUrl}/v1/health`, { signal: AbortSignal.timeout(5_000) }),
-    ])
-    if (attempt.status === 'fulfilled' && attempt.value.ok) {
-      const data = await attempt.value.json()
-      if (data?.status === 'ok') return
-    }
-    await delay(500)
-  }
-  throw new Error('Timed out waiting for /v1/health')
+	console.log('Starting Sandbox Agent');
+	const sdk = await SandboxAgent.start({
+		sandbox: e2b({
+			create: { envs },
+		})
+	});
+
+	try {
+		const session = await sdk.createSession({ agent: "claude" });
+		console.log(sdk.inspectorUrl);
+		const response = await session.prompt([
+			{ type: "text", text: "Summarize this repository" },
+		]);
+		console.log(response.stopReason);
+
+		console.log('Sandbox Agent is ready.');
+		// console.log(`Inspector URL: ${baseUrl}/ui/sessions/${encodeURIComponent(session.id)}`);
+
+
+		// Uncomment to run one prompt and stream events in your terminal.
+		// const off = session.onEvent((event) => {
+		//	 console.log(`[event] ${event.type}`)
+		// })
+		// await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
+		// off()
+	} finally {
+		await sdk.destroySandbox();
+	}
 }
 
-const envs: Record<string, string> = {}
-if (process.env.ANTHROPIC_API_KEY) envs.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY
-if (process.env.OPENAI_API_KEY) envs.OPENAI_API_KEY = process.env.OPENAI_API_KEY
-if (process.env.CODEX_API_KEY) envs.CODEX_API_KEY = process.env.CODEX_API_KEY
-if (!envs.CODEX_API_KEY && envs.OPENAI_API_KEY) envs.CODEX_API_KEY = envs.OPENAI_API_KEY
-
-if (!envs.OPENAI_API_KEY && !envs.CODEX_API_KEY && !envs.ANTHROPIC_API_KEY) {
-  throw new Error('Set OPENAI_API_KEY/CODEX_API_KEY or ANTHROPIC_API_KEY')
-}
-
-const agent = envs.ANTHROPIC_API_KEY ? 'claude' : 'codex'
-console.log(`Creating E2B sandbox from template "${E2B_TEMPLATE}"...`)
-const sandbox = await Sandbox.create(E2B_TEMPLATE, { envs })
-console.log(`E2B sandbox ID: ${sandbox.sandboxId}`)
-
-const run = async (command: string) => {
-  const result = await sandbox.commands.run(command)
-  if (result.exitCode !== 0) {
-    throw new Error(`Command failed (${result.exitCode}): ${command}\n${(result.stderr || result.stdout || '').trim()}`)
-  }
-}
-
-console.log('Installing Sandbox Agent CLI...')
-await run(
-  `bash -lc 'set -euo pipefail; curl -fsSL https://releases.rivet.dev/sandbox-agent/${SANDBOX_AGENT_CLI_VERSION}/install.sh | sh; sandbox-agent --version'`,
-)
-
-console.log(`Installing agent (${agent})...`)
-await run(`sandbox-agent install-agent ${agent}`)
-
-console.log('Starting Sandbox Agent server...')
-await run(`sandbox-agent --no-token server --host 0.0.0.0 --port ${SERVER_PORT} >/tmp/sandbox-agent.log 2>&1 &`)
-await run("sleep 1; pgrep -af 'sandbox-agent.*server' >/dev/null")
-
-const baseUrl = `https://${sandbox.getHost(SERVER_PORT)}`
-console.log('Waiting for /v1/health...')
-await waitForHealth(baseUrl)
-
-const sdk = await SandboxAgent.connect({ baseUrl })
-const session = await sdk.createSession({ agent })
-
-console.log('Sandbox Agent is ready.')
-console.log(`Inspector URL: ${baseUrl}/ui/sessions/${encodeURIComponent(session.id)}`)
-
-// Uncomment to run one prompt and stream events in your terminal.
-// const off = session.onEvent((event) => {
-//   console.log(`[event] ${event.type}`)
-// })
-// await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
-// off()
-
-await sdk.dispose()
-await sandbox.kill()
+main();

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -21,7 +21,7 @@ async function main() {
 
 	try {
 		const session = await sdk.createSession({ agent: "claude" });
-		console.log(`Inspector URL: ${sdk.inspectorUrl}sessions/${encodeURIComponent(session.agentSessionId)}`);
+		console.log(`Inspector URL: ${sdk.inspectorUrl}`);
 
 		const response = await session.prompt([
 			{ type: "text", text: "Summarize this repository" },

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -20,17 +20,19 @@ async function main() {
 	});
 	console.log(`Ready. Visit Sandbox Agent inspector URL: ${sdk.inspectorUrl}`);
 
-	try {
-		// Uncomment to run one prompt and stream events in your terminal.
-		// const session = await sdk.createSession({ agent: "claude" });
-		// const off = session.onEvent((event) => {
-		// 	 console.log(`[event] from ${event.sender}`, event.payload);
-		// })
-		// await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
-		// off()
-	} finally {
+	// Uncomment to run one prompt and stream events in your terminal.
+	// const session = await sdk.createSession({ agent: "claude" });
+	// const off = session.onEvent((event) => {
+	// 	 console.log(`[event] from ${event.sender}`, event.payload);
+	// })
+	// await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
+	// off()
+
+	process.on("SIGINT", async () => {
+		console.log("Destroying sandbox");
 		await sdk.destroySandbox();
-	}
+		process.exit();
+	});
 }
 
 main();

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -1,0 +1,110 @@
+import 'dotenv/config'
+import { Sandbox } from 'e2b'
+import { SandboxAgent } from 'sandbox-agent'
+
+const SERVER_TOKEN = 'sandbox-agent-e2b-demo-token'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function detectAgent(envs: Record<string, string>): string {
+  const explicitAgent = process.env.SANDBOX_AGENT?.trim()
+  if (explicitAgent) return explicitAgent
+
+  if (envs.OPENAI_API_KEY || envs.CODEX_API_KEY) return 'codex'
+  if (envs.ANTHROPIC_API_KEY) return 'claude'
+
+  throw new Error('Set SANDBOX_AGENT or provide OPENAI_API_KEY/CODEX_API_KEY/ANTHROPIC_API_KEY')
+}
+
+function inspectorUrl(baseUrl: string, token: string, sessionId: string): string {
+  return `${baseUrl}/ui/?token=${encodeURIComponent(token)}&sessionId=${encodeURIComponent(sessionId)}`
+}
+
+async function waitForHealth(baseUrl: string, token: string): Promise<void> {
+  const deadline = Date.now() + 120_000
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/v1/health`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5_000),
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+        if (data?.status === 'ok') return
+      }
+    } catch {
+      // Ignore transient startup failures while polling health.
+    }
+
+    await sleep(500)
+  }
+
+  throw new Error('Timed out waiting for Sandbox Agent server health check')
+}
+
+const envs: Record<string, string> = {}
+if (process.env.ANTHROPIC_API_KEY) envs.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY
+if (process.env.OPENAI_API_KEY) envs.OPENAI_API_KEY = process.env.OPENAI_API_KEY
+if (process.env.CODEX_API_KEY) envs.CODEX_API_KEY = process.env.CODEX_API_KEY
+if (!envs.CODEX_API_KEY && envs.OPENAI_API_KEY) envs.CODEX_API_KEY = envs.OPENAI_API_KEY
+
+const agent = detectAgent(envs)
+
+console.log('Creating E2B sandbox...')
+const sandbox = await Sandbox.create({ envs })
+let client: SandboxAgent | undefined
+
+try {
+  console.log(`E2B sandbox ID: ${sandbox.sandboxId}`)
+
+  const run = async (command: string) => {
+    const result = await sandbox.commands.run(command)
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Command failed (${result.exitCode}): ${command}\n${(result.stderr || result.stdout || '').trim()}`
+      )
+    }
+  }
+
+  console.log('Installing Sandbox Agent CLI...')
+  await run(
+    "bash -lc 'set -euo pipefail; curl -fsSL https://releases.rivet.dev/sandbox-agent/0.2.x/install.sh | sh; command -v sandbox-agent >/dev/null; sandbox-agent --version'"
+  )
+
+  console.log(`Installing agent (${agent})...`)
+  await run(`sandbox-agent install-agent ${agent}`)
+
+  console.log('Starting Sandbox Agent server...')
+  await run(`sandbox-agent server --token ${SERVER_TOKEN} --host 0.0.0.0 --port 3000 >/tmp/sandbox-agent.log 2>&1 &`)
+  await run("sleep 1; pgrep -af 'sandbox-agent server' >/dev/null")
+
+  const baseUrl = `https://${sandbox.getHost(3000)}`
+
+  console.log('Waiting for /v1/health...')
+  await waitForHealth(baseUrl, SERVER_TOKEN)
+
+  client = await SandboxAgent.connect({ baseUrl, token: SERVER_TOKEN })
+  const session = await client.createSession({
+    agent,
+    sessionInit: { cwd: '/home/user', mcpServers: [] },
+  })
+
+  console.log('Sandbox Agent is ready.')
+  console.log(`Inspector URL: ${inspectorUrl(baseUrl, SERVER_TOKEN, session.id)}`)
+
+  // Optional: uncomment to run a prompt through the agent.
+  // await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
+} finally {
+  if (client) {
+    try {
+      await client.dispose()
+    } catch {
+      // Ignore dispose errors during shutdown.
+    }
+  }
+  await sandbox.kill()
+}

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -21,6 +21,7 @@ async function main() {
 	console.log(`Ready. Visit Sandbox Agent inspector URL: ${sdk.inspectorUrl}`);
 
 	// Uncomment to run one prompt and stream events in your terminal.
+	// Read more about Sessions and Events here: https://sandboxagent.dev/docs/agent-sessions.
 	// const session = await sdk.createSession({ agent: "claude" });
 	// const off = session.onEvent((event) => {
 	// 	 console.log(`[event] from ${event.sender}`, event.payload);

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -18,20 +18,11 @@ async function main() {
 			create: { envs },
 		})
 	});
+	console.log(`Ready. Visit Sandbox Agent inspector URL: ${sdk.inspectorUrl}`);
 
 	try {
-		const session = await sdk.createSession({ agent: "claude" });
-		console.log(`Inspector URL: ${sdk.inspectorUrl}`);
-
-		const response = await session.prompt([
-			{ type: "text", text: "Summarize this repository" },
-		]);
-		console.log(response.stopReason);
-
-		console.log('Sandbox Agent is ready.');
-
-
 		// Uncomment to run one prompt and stream events in your terminal.
+		// const session = await sdk.createSession({ agent: "claude" });
 		// const off = session.onEvent((event) => {
 		// 	 console.log(`[event] from ${event.sender}`, event.payload);
 		// })

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -6,35 +6,20 @@ import { SandboxAgent } from 'sandbox-agent'
 const SERVER_PORT = 3000
 const SANDBOX_AGENT_CLI_VERSION = '0.2.x'
 const E2B_TEMPLATE = process.env.E2B_TEMPLATE?.trim() || 'base'
-const HEALTH_TIMEOUT_MS = 120_000
-
-function chooseAgent(envs: Record<string, string>): string {
-  if (envs.OPENAI_API_KEY || envs.CODEX_API_KEY) return 'codex'
-  if (envs.ANTHROPIC_API_KEY) return 'claude'
-  throw new Error('Set OPENAI_API_KEY/CODEX_API_KEY or ANTHROPIC_API_KEY')
-}
 
 async function waitForHealth(baseUrl: string): Promise<void> {
-  const deadline = Date.now() + HEALTH_TIMEOUT_MS
-
+  const deadline = Date.now() + 120_000
   while (Date.now() < deadline) {
-    try {
-      const response = await fetch(`${baseUrl}/v1/health`, {
-        signal: AbortSignal.timeout(5_000),
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        if (data?.status === 'ok') return
-      }
-    } catch {
-      // Ignore transient startup failures while polling health.
+    const [attempt] = await Promise.allSettled([
+      fetch(`${baseUrl}/v1/health`, { signal: AbortSignal.timeout(5_000) }),
+    ])
+    if (attempt.status === 'fulfilled' && attempt.value.ok) {
+      const data = await attempt.value.json()
+      if (data?.status === 'ok') return
     }
-
     await delay(500)
   }
-
-  throw new Error('Timed out waiting for Sandbox Agent health endpoint')
+  throw new Error('Timed out waiting for /v1/health')
 }
 
 const envs: Record<string, string> = {}
@@ -43,59 +28,50 @@ if (process.env.OPENAI_API_KEY) envs.OPENAI_API_KEY = process.env.OPENAI_API_KEY
 if (process.env.CODEX_API_KEY) envs.CODEX_API_KEY = process.env.CODEX_API_KEY
 if (!envs.CODEX_API_KEY && envs.OPENAI_API_KEY) envs.CODEX_API_KEY = envs.OPENAI_API_KEY
 
-const agent = chooseAgent(envs)
+if (!envs.OPENAI_API_KEY && !envs.CODEX_API_KEY && !envs.ANTHROPIC_API_KEY) {
+  throw new Error('Set OPENAI_API_KEY/CODEX_API_KEY or ANTHROPIC_API_KEY')
+}
 
+const agent = envs.ANTHROPIC_API_KEY ? 'claude' : 'codex'
 console.log(`Creating E2B sandbox from template "${E2B_TEMPLATE}"...`)
 const sandbox = await Sandbox.create(E2B_TEMPLATE, { envs })
-let sdk: SandboxAgent | undefined
+console.log(`E2B sandbox ID: ${sandbox.sandboxId}`)
 
-try {
-  console.log(`E2B sandbox ID: ${sandbox.sandboxId}`)
-
-  const run = async (command: string) => {
-    const result = await sandbox.commands.run(command)
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Command failed (${result.exitCode}): ${command}\n${(result.stderr || result.stdout || '').trim()}`,
-      )
-    }
+const run = async (command: string) => {
+  const result = await sandbox.commands.run(command)
+  if (result.exitCode !== 0) {
+    throw new Error(`Command failed (${result.exitCode}): ${command}\n${(result.stderr || result.stdout || '').trim()}`)
   }
-
-  console.log('Installing Sandbox Agent CLI...')
-  await run(
-    `bash -lc 'set -euo pipefail; curl -fsSL https://releases.rivet.dev/sandbox-agent/${SANDBOX_AGENT_CLI_VERSION}/install.sh | sh; sandbox-agent --version'`,
-  )
-
-  console.log(`Installing agent (${agent})...`)
-  await run(`sandbox-agent install-agent ${agent}`)
-
-  console.log('Starting Sandbox Agent server...')
-  await run(`sandbox-agent --no-token server --host 0.0.0.0 --port ${SERVER_PORT} >/tmp/sandbox-agent.log 2>&1 &`)
-  await run("sleep 1; pgrep -af 'sandbox-agent.*server' >/dev/null")
-
-  const baseUrl = `https://${sandbox.getHost(SERVER_PORT)}`
-  console.log('Waiting for /v1/health...')
-  await waitForHealth(baseUrl)
-
-  sdk = await SandboxAgent.connect({ baseUrl })
-  const session = await sdk.createSession({ agent })
-
-  console.log('Sandbox Agent is ready.')
-  console.log(`Inspector URL: ${baseUrl}/ui/sessions/${encodeURIComponent(session.id)}`)
-
-  // Uncomment to run one prompt and stream events in your terminal.
-  // const off = session.onEvent((event) => {
-  //   console.log(`[event] ${event.type}`)
-  // })
-  // await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
-  // off()
-} finally {
-  if (sdk) {
-    try {
-      await sdk.dispose()
-    } catch {
-      // Ignore dispose errors during shutdown.
-    }
-  }
-  await sandbox.kill()
 }
+
+console.log('Installing Sandbox Agent CLI...')
+await run(
+  `bash -lc 'set -euo pipefail; curl -fsSL https://releases.rivet.dev/sandbox-agent/${SANDBOX_AGENT_CLI_VERSION}/install.sh | sh; sandbox-agent --version'`,
+)
+
+console.log(`Installing agent (${agent})...`)
+await run(`sandbox-agent install-agent ${agent}`)
+
+console.log('Starting Sandbox Agent server...')
+await run(`sandbox-agent --no-token server --host 0.0.0.0 --port ${SERVER_PORT} >/tmp/sandbox-agent.log 2>&1 &`)
+await run("sleep 1; pgrep -af 'sandbox-agent.*server' >/dev/null")
+
+const baseUrl = `https://${sandbox.getHost(SERVER_PORT)}`
+console.log('Waiting for /v1/health...')
+await waitForHealth(baseUrl)
+
+const sdk = await SandboxAgent.connect({ baseUrl })
+const session = await sdk.createSession({ agent })
+
+console.log('Sandbox Agent is ready.')
+console.log(`Inspector URL: ${baseUrl}/ui/sessions/${encodeURIComponent(session.id)}`)
+
+// Uncomment to run one prompt and stream events in your terminal.
+// const off = session.onEvent((event) => {
+//   console.log(`[event] ${event.type}`)
+// })
+// await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
+// off()
+
+await sdk.dispose()
+await sandbox.kill()

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -21,7 +21,7 @@ async function main() {
 	console.log(`Ready. Visit Sandbox Agent inspector URL: ${sdk.inspectorUrl}`);
 
 	// Uncomment to run one prompt and stream events in your terminal.
-	// Read more about Sessions and Events here: https://sandboxagent.dev/docs/agent-sessions.
+	// Read more about Sessions and Events here: https://sandboxagent.dev/docs/agent-sessions
 	// const session = await sdk.createSession({ agent: "claude" });
 	// const off = session.onEvent((event) => {
 	// 	 console.log(`[event] from ${event.sender}`, event.payload);

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -98,6 +98,14 @@ try {
 
   // Optional: uncomment to run a prompt through the agent.
   // await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
+
+  if (process.env.KEEP_ALIVE === '1') {
+    console.log('KEEP_ALIVE=1 set. Press Ctrl+C to stop and delete the sandbox.')
+    // Keep process alive until interrupted so you can open the Inspector URL.
+    while (true) {
+      await sleep(60_000)
+    }
+  }
 } finally {
   if (client) {
     try {

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -10,13 +10,13 @@ function sleep(ms: number): Promise<void> {
 }
 
 function detectAgent(envs: Record<string, string>): string {
-  const explicitAgent = process.env.SANDBOX_AGENT?.trim()
+  const explicitAgent = process.env.AGENT?.trim()
   if (explicitAgent) return explicitAgent
 
   if (envs.OPENAI_API_KEY || envs.CODEX_API_KEY) return 'codex'
   if (envs.ANTHROPIC_API_KEY) return 'claude'
 
-  throw new Error('Set SANDBOX_AGENT or provide OPENAI_API_KEY/CODEX_API_KEY/ANTHROPIC_API_KEY')
+  throw new Error('Set AGENT or provide OPENAI_API_KEY/CODEX_API_KEY/ANTHROPIC_API_KEY')
 }
 
 function inspectorUrl(baseUrl: string, token: string, sessionId: string): string {

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -1,35 +1,25 @@
 import 'dotenv/config'
+import { setTimeout as delay } from 'node:timers/promises'
 import { Sandbox } from 'e2b'
 import { SandboxAgent } from 'sandbox-agent'
 
-const SERVER_TOKEN = 'sandbox-agent-e2b-demo-token'
-const KEEP_ALIVE = process.env.KEEP_ALIVE === '1'
+const SERVER_PORT = 3000
+const SANDBOX_AGENT_CLI_VERSION = '0.2.x'
+const E2B_TEMPLATE = process.env.E2B_TEMPLATE?.trim() || 'base'
+const HEALTH_TIMEOUT_MS = 120_000
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-function detectAgent(envs: Record<string, string>): string {
-  const explicitAgent = process.env.AGENT?.trim()
-  if (explicitAgent) return explicitAgent
-
+function chooseAgent(envs: Record<string, string>): string {
   if (envs.OPENAI_API_KEY || envs.CODEX_API_KEY) return 'codex'
   if (envs.ANTHROPIC_API_KEY) return 'claude'
-
-  throw new Error('Set AGENT or provide OPENAI_API_KEY/CODEX_API_KEY/ANTHROPIC_API_KEY')
+  throw new Error('Set OPENAI_API_KEY/CODEX_API_KEY or ANTHROPIC_API_KEY')
 }
 
-function inspectorUrl(baseUrl: string, token: string, sessionId: string): string {
-  return `${baseUrl}/ui/?token=${encodeURIComponent(token)}&sessionId=${encodeURIComponent(sessionId)}`
-}
-
-async function waitForHealth(baseUrl: string, token: string): Promise<void> {
-  const deadline = Date.now() + 120_000
+async function waitForHealth(baseUrl: string): Promise<void> {
+  const deadline = Date.now() + HEALTH_TIMEOUT_MS
 
   while (Date.now() < deadline) {
     try {
       const response = await fetch(`${baseUrl}/v1/health`, {
-        headers: { Authorization: `Bearer ${token}` },
         signal: AbortSignal.timeout(5_000),
       })
 
@@ -41,10 +31,10 @@ async function waitForHealth(baseUrl: string, token: string): Promise<void> {
       // Ignore transient startup failures while polling health.
     }
 
-    await sleep(500)
+    await delay(500)
   }
 
-  throw new Error('Timed out waiting for Sandbox Agent server health check')
+  throw new Error('Timed out waiting for Sandbox Agent health endpoint')
 }
 
 const envs: Record<string, string> = {}
@@ -53,96 +43,56 @@ if (process.env.OPENAI_API_KEY) envs.OPENAI_API_KEY = process.env.OPENAI_API_KEY
 if (process.env.CODEX_API_KEY) envs.CODEX_API_KEY = process.env.CODEX_API_KEY
 if (!envs.CODEX_API_KEY && envs.OPENAI_API_KEY) envs.CODEX_API_KEY = envs.OPENAI_API_KEY
 
-const agent = detectAgent(envs)
+const agent = chooseAgent(envs)
 
-console.log('Creating E2B sandbox...')
-const sandbox = await Sandbox.create({ envs })
-let client: SandboxAgent | undefined
+console.log(`Creating E2B sandbox from template "${E2B_TEMPLATE}"...`)
+const sandbox = await Sandbox.create(E2B_TEMPLATE, { envs })
+let sdk: SandboxAgent | undefined
 
 try {
   console.log(`E2B sandbox ID: ${sandbox.sandboxId}`)
-
-  if (KEEP_ALIVE) {
-    // If the runtime closes a long-lived connection (SSE/stream), don't crash and
-    // implicitly delete the sandbox. In KEEP_ALIVE mode we want the sandbox to stay up.
-    process.on('unhandledRejection', (error) => {
-      console.error('Unhandled rejection:', error)
-    })
-    process.on('uncaughtException', (error) => {
-      console.error('Uncaught exception:', error)
-    })
-
-    const cleanupAndExit = async (code: number) => {
-      try {
-        if (client) await client.dispose()
-      } catch {
-        // ignore
-      }
-      try {
-        await sandbox.kill()
-      } catch (error) {
-        console.error('Failed to kill sandbox:', error)
-      }
-      process.exit(code)
-    }
-
-    process.once('SIGINT', () => void cleanupAndExit(0))
-    process.once('SIGTERM', () => void cleanupAndExit(0))
-  }
 
   const run = async (command: string) => {
     const result = await sandbox.commands.run(command)
     if (result.exitCode !== 0) {
       throw new Error(
-        `Command failed (${result.exitCode}): ${command}\n${(result.stderr || result.stdout || '').trim()}`
+        `Command failed (${result.exitCode}): ${command}\n${(result.stderr || result.stdout || '').trim()}`,
       )
     }
   }
 
   console.log('Installing Sandbox Agent CLI...')
   await run(
-    "bash -lc 'set -euo pipefail; curl -fsSL https://releases.rivet.dev/sandbox-agent/0.2.x/install.sh | sh; command -v sandbox-agent >/dev/null; sandbox-agent --version'"
+    `bash -lc 'set -euo pipefail; curl -fsSL https://releases.rivet.dev/sandbox-agent/${SANDBOX_AGENT_CLI_VERSION}/install.sh | sh; sandbox-agent --version'`,
   )
 
   console.log(`Installing agent (${agent})...`)
   await run(`sandbox-agent install-agent ${agent}`)
 
   console.log('Starting Sandbox Agent server...')
-  await run(`sandbox-agent server --token ${SERVER_TOKEN} --host 0.0.0.0 --port 3000 >/tmp/sandbox-agent.log 2>&1 &`)
-  await run("sleep 1; pgrep -af 'sandbox-agent server' >/dev/null")
+  await run(`sandbox-agent --no-token server --host 0.0.0.0 --port ${SERVER_PORT} >/tmp/sandbox-agent.log 2>&1 &`)
+  await run("sleep 1; pgrep -af 'sandbox-agent.*server' >/dev/null")
 
-  const baseUrl = `https://${sandbox.getHost(3000)}`
-
+  const baseUrl = `https://${sandbox.getHost(SERVER_PORT)}`
   console.log('Waiting for /v1/health...')
-  await waitForHealth(baseUrl, SERVER_TOKEN)
+  await waitForHealth(baseUrl)
 
-  client = await SandboxAgent.connect({ baseUrl, token: SERVER_TOKEN })
-  const session = await client.createSession({
-    agent,
-    sessionInit: { cwd: '/home/user', mcpServers: [] },
-  })
+  sdk = await SandboxAgent.connect({ baseUrl })
+  const session = await sdk.createSession({ agent })
 
   console.log('Sandbox Agent is ready.')
-  console.log(`Inspector URL: ${inspectorUrl(baseUrl, SERVER_TOKEN, session.id)}`)
+  console.log(`Inspector URL: ${baseUrl}/ui/sessions/${encodeURIComponent(session.id)}`)
 
-  // Optional: uncomment to run a prompt through the agent.
+  // Uncomment to run one prompt and stream events in your terminal.
+  // const off = session.onEvent((event) => {
+  //   console.log(`[event] ${event.type}`)
+  // })
   // await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
-
-  if (process.env.KEEP_ALIVE === '1') {
-    // Close the SDK transport (streams/SSE) but keep the sandbox + server running.
-    // The Inspector UI talks directly to the server URL.
-    await client.dispose()
-    client = undefined
-    console.log('KEEP_ALIVE=1 set. Press Ctrl+C to stop and delete the sandbox.')
-    // Keep process alive until interrupted so you can open the Inspector URL.
-    while (true) {
-      await sleep(60_000)
-    }
-  }
+  // off()
 } finally {
-  if (client) {
+  if (sdk) {
     try {
-      await client.dispose()
+      await sdk.dispose()
     } catch {
       // Ignore dispose errors during shutdown.
     }

--- a/examples/sandbox-agent-sdk-js/src/index.ts
+++ b/examples/sandbox-agent-sdk-js/src/index.ts
@@ -21,19 +21,19 @@ async function main() {
 
 	try {
 		const session = await sdk.createSession({ agent: "claude" });
-		console.log(sdk.inspectorUrl);
+		console.log(`Inspector URL: ${sdk.inspectorUrl}sessions/${encodeURIComponent(session.agentSessionId)}`);
+
 		const response = await session.prompt([
 			{ type: "text", text: "Summarize this repository" },
 		]);
 		console.log(response.stopReason);
 
 		console.log('Sandbox Agent is ready.');
-		// console.log(`Inspector URL: ${baseUrl}/ui/sessions/${encodeURIComponent(session.id)}`);
 
 
 		// Uncomment to run one prompt and stream events in your terminal.
 		// const off = session.onEvent((event) => {
-		//	 console.log(`[event] ${event.type}`)
+		// 	 console.log(`[event] from ${event.sender}`, event.payload);
 		// })
 		// await session.prompt([{ type: 'text', text: 'Reply with exactly: sandbox-agent-ready' }])
 		// off()

--- a/tests/examples.test.ts
+++ b/tests/examples.test.ts
@@ -38,6 +38,7 @@ const scripts = [
   { name: 'mcp-claude-code-js', interpreter: 'npm', file: './examples/mcp-claude-code-js/' },
   { name: 'mcp-browserbase-js', interpreter: 'npm', file: './examples/mcp-browserbase-js/' },
   { name: 'mcp-groq-exa-js', interpreter: 'npm', file: './examples/mcp-groq-exa-js/' },
+  { name: 'sandbox-agent-sdk-js', interpreter: 'npm', file: './examples/sandbox-agent-sdk-js/' },
 ];
 
 // We don't have integration tests for NextJS yet:


### PR DESCRIPTION
# Summary
Added a new example project `sandbox-agent-sdk-js` that shows how to run the Sandbox Agent in an E2B sandbox and interact with it using the Sandbox Agent SDK.

Includes sample implementation in `src/index.ts` that manages environment variables, session creation, and prompt handling.

Updated the main `README.md` to include the new Sandbox Agent SDK example in the list of available examples, linking to its documentation and source.
