### PR TITLE
Add Bilig WorkPaper formula readback example

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ Read more about E2B on the [E2B website](https://e2b.dev) and the official [E2B 
       <td><a href="./examples/mcp-research-agent-js">TypeScript</a></td>
     </tr>
     <tr>
+      <td>Bilig WorkPaper Formula Readback</td>
+      <td>Run spreadsheet formula readback proof inside an E2B sandbox</td>
+      <td><a href="./examples/bilig-workpaper-formula-readback-js">TypeScript</a></td>
+    </tr>
+    <tr>
       <td>MCP Claude Code</td>
       <td>Claude Code with MCP integration</td>
       <td><a href="./examples/mcp-claude-code-js">TypeScript</a></td>

--- a/examples/bilig-workpaper-formula-readback-js/README.md
+++ b/examples/bilig-workpaper-formula-readback-js/README.md
@@ -1,0 +1,49 @@
+# Bilig WorkPaper Formula Readback
+
+Run a spreadsheet-style formula workbook inside an E2B sandbox and verify that an agent-style cell edit really recalculates dependent formulas.
+
+This example installs [`@bilig/workpaper`](https://github.com/proompteng/bilig) inside the sandbox, creates a small WorkPaper model, changes one input cell, and checks three things before returning JSON:
+
+- formula cells stayed formulas after the edit;
+- dependent calculated values changed;
+- exported WorkPaper JSON restores to the same calculated result.
+
+Use this shape when an agent needs spreadsheet logic but should not drive Excel, LibreOffice, or a browser UI.
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Copy environment variables:
+
+   ```bash
+   cp env.template .env
+   ```
+
+3. Set your E2B key:
+
+   ```bash
+   E2B_API_KEY=your_e2b_api_key
+   ```
+
+4. Run the example:
+
+   ```bash
+   npm run start
+   ```
+
+## What it does
+
+- Creates a fresh E2B sandbox.
+- Uploads a small WorkPaper verification script into `/tmp`.
+- Installs `@bilig/workpaper@0.107.8` in the sandbox at runtime.
+- Builds a workbook with input and formula sheets.
+- Edits `Assumptions!B3` from `0.25` to `0.4`.
+- Reads calculated output before and after the edit.
+- Serializes and restores the WorkPaper JSON to prove the computed result survives persistence.
+
+A successful run prints a JSON proof object with `verified: true`.

--- a/examples/bilig-workpaper-formula-readback-js/README.md
+++ b/examples/bilig-workpaper-formula-readback-js/README.md
@@ -40,7 +40,7 @@ Use this shape when an agent needs spreadsheet logic but should not drive Excel,
 
 - Creates a fresh E2B sandbox.
 - Uploads a small WorkPaper verification script into `/tmp`.
-- Installs `@bilig/workpaper@0.154.0` in the sandbox at runtime.
+- Installs `@bilig/workpaper@0.157.0` in the sandbox at runtime.
 - Builds a workbook with input and formula sheets.
 - Edits `Assumptions!B3` from `0.25` to `0.4`.
 - Reads calculated output before and after the edit.

--- a/examples/bilig-workpaper-formula-readback-js/README.md
+++ b/examples/bilig-workpaper-formula-readback-js/README.md
@@ -40,7 +40,7 @@ Use this shape when an agent needs spreadsheet logic but should not drive Excel,
 
 - Creates a fresh E2B sandbox.
 - Uploads a small WorkPaper verification script into `/tmp`.
-- Installs `@bilig/workpaper@0.131.3` in the sandbox at runtime.
+- Installs `@bilig/workpaper@0.154.0` in the sandbox at runtime.
 - Builds a workbook with input and formula sheets.
 - Edits `Assumptions!B3` from `0.25` to `0.4`.
 - Reads calculated output before and after the edit.

--- a/examples/bilig-workpaper-formula-readback-js/README.md
+++ b/examples/bilig-workpaper-formula-readback-js/README.md
@@ -40,7 +40,7 @@ Use this shape when an agent needs spreadsheet logic but should not drive Excel,
 
 - Creates a fresh E2B sandbox.
 - Uploads a small WorkPaper verification script into `/tmp`.
-- Installs `@bilig/workpaper@0.131.2` in the sandbox at runtime.
+- Installs `@bilig/workpaper@0.131.3` in the sandbox at runtime.
 - Builds a workbook with input and formula sheets.
 - Edits `Assumptions!B3` from `0.25` to `0.4`.
 - Reads calculated output before and after the edit.

--- a/examples/bilig-workpaper-formula-readback-js/README.md
+++ b/examples/bilig-workpaper-formula-readback-js/README.md
@@ -40,7 +40,7 @@ Use this shape when an agent needs spreadsheet logic but should not drive Excel,
 
 - Creates a fresh E2B sandbox.
 - Uploads a small WorkPaper verification script into `/tmp`.
-- Installs `@bilig/workpaper@0.131.1` in the sandbox at runtime.
+- Installs `@bilig/workpaper@0.131.2` in the sandbox at runtime.
 - Builds a workbook with input and formula sheets.
 - Edits `Assumptions!B3` from `0.25` to `0.4`.
 - Reads calculated output before and after the edit.

--- a/examples/bilig-workpaper-formula-readback-js/README.md
+++ b/examples/bilig-workpaper-formula-readback-js/README.md
@@ -40,7 +40,7 @@ Use this shape when an agent needs spreadsheet logic but should not drive Excel,
 
 - Creates a fresh E2B sandbox.
 - Uploads a small WorkPaper verification script into `/tmp`.
-- Installs `@bilig/workpaper@0.107.8` in the sandbox at runtime.
+- Installs `@bilig/workpaper@0.130.7` in the sandbox at runtime.
 - Builds a workbook with input and formula sheets.
 - Edits `Assumptions!B3` from `0.25` to `0.4`.
 - Reads calculated output before and after the edit.

--- a/examples/bilig-workpaper-formula-readback-js/README.md
+++ b/examples/bilig-workpaper-formula-readback-js/README.md
@@ -40,7 +40,7 @@ Use this shape when an agent needs spreadsheet logic but should not drive Excel,
 
 - Creates a fresh E2B sandbox.
 - Uploads a small WorkPaper verification script into `/tmp`.
-- Installs `@bilig/workpaper@0.130.7` in the sandbox at runtime.
+- Installs `@bilig/workpaper@0.131.1` in the sandbox at runtime.
 - Builds a workbook with input and formula sheets.
 - Edits `Assumptions!B3` from `0.25` to `0.4`.
 - Reads calculated output before and after the edit.

--- a/examples/bilig-workpaper-formula-readback-js/env.template
+++ b/examples/bilig-workpaper-formula-readback-js/env.template
@@ -1,0 +1,1 @@
+E2B_API_KEY=your_e2b_api_key

--- a/examples/bilig-workpaper-formula-readback-js/index.ts
+++ b/examples/bilig-workpaper-formula-readback-js/index.ts
@@ -1,0 +1,165 @@
+import 'dotenv/config';
+import { Sandbox } from 'e2b';
+
+const workdir = '/tmp/bilig-workpaper-formula-readback';
+
+const proofScript = String.raw`
+import {
+  WorkPaper,
+  createWorkPaperFromDocument,
+  exportWorkPaperDocument,
+  parseWorkPaperDocument,
+  serializeWorkPaperDocument,
+} from '@bilig/workpaper';
+
+const workbook = WorkPaper.buildFromSheets({
+  Assumptions: [
+    ['Metric', 'Value'],
+    ['Qualified opportunities', 20],
+    ['Win rate', 0.25],
+    ['Average ARR', 12000],
+    ['Expansion multiplier', 1.1],
+  ],
+  Summary: [
+    ['Metric', 'Value'],
+    ['Expected customers', '=Assumptions!B2*Assumptions!B3'],
+    ['Expected ARR', '=B2*Assumptions!B4'],
+    ['Expansion ARR', '=B3*Assumptions!B5'],
+    ['Target gap', '=B4-100000'],
+  ],
+});
+
+const assumptionsSheet = requireSheet(workbook, 'Assumptions');
+const summarySheet = requireSheet(workbook, 'Summary');
+
+const before = readSummary(workbook, summarySheet);
+const beforeFormulas = readFormulaContracts(workbook, summarySheet);
+const previousValue = workbook.getCellSerialized({ sheet: assumptionsSheet, row: 2, col: 1 });
+
+workbook.setCellContents({ sheet: assumptionsSheet, row: 2, col: 1 }, 0.4);
+
+const after = readSummary(workbook, summarySheet);
+const afterFormulas = readFormulaContracts(workbook, summarySheet);
+const serialized = serializeWorkPaperDocument(exportWorkPaperDocument(workbook, { includeConfig: true }));
+const restored = createWorkPaperFromDocument(parseWorkPaperDocument(serialized));
+const restoredSummarySheet = requireSheet(restored, 'Summary');
+const restoredSummary = readSummary(restored, restoredSummarySheet);
+const restoredFormulas = readFormulaContracts(restored, restoredSummarySheet);
+
+const output = {
+  editedCell: 'Assumptions!B3',
+  before,
+  after,
+  restored: restoredSummary,
+  formulas: afterFormulas,
+  checks: {
+    previousValue,
+    newValue: workbook.getCellSerialized({ sheet: assumptionsSheet, row: 2, col: 1 }),
+    formulasUnchanged: sameJson(beforeFormulas, afterFormulas),
+    formulasPersisted: sameJson(afterFormulas, restoredFormulas),
+    computedOutputChanged: before.expectedArr !== after.expectedArr,
+    restoredMatchesAfter: sameJson(after, restoredSummary),
+    serializedBytes: Buffer.byteLength(serialized, 'utf8'),
+  },
+};
+
+const verified =
+  output.checks.previousValue === 0.25 &&
+  output.checks.newValue === 0.4 &&
+  output.checks.formulasUnchanged &&
+  output.checks.formulasPersisted &&
+  output.checks.computedOutputChanged &&
+  output.checks.restoredMatchesAfter &&
+  output.checks.serializedBytes > 0 &&
+  output.before.expectedArr === 60000 &&
+  output.after.expectedArr === 96000;
+
+if (!verified) {
+  throw new Error('Bilig WorkPaper verification failed: ' + JSON.stringify(output));
+}
+
+console.log(JSON.stringify({ verified, ...output }, null, 2));
+
+function requireSheet(workpaper, sheetName) {
+  const sheetId = workpaper.getSheetId(sheetName);
+  if (sheetId === undefined) {
+    throw new Error('Expected sheet "' + sheetName + '" to exist');
+  }
+  return sheetId;
+}
+
+function readSummary(workpaper, sheet) {
+  return {
+    expectedCustomers: readNumber(workpaper, sheet, 1, 1, 'expected customers'),
+    expectedArr: readNumber(workpaper, sheet, 2, 1, 'expected ARR'),
+    expansionArr: readNumber(workpaper, sheet, 3, 1, 'expansion ARR'),
+    targetGap: readNumber(workpaper, sheet, 4, 1, 'target gap'),
+  };
+}
+
+function readFormulaContracts(workpaper, sheet) {
+  return {
+    expectedCustomers: readFormula(workpaper, sheet, 1, 1, 'expected customers'),
+    expectedArr: readFormula(workpaper, sheet, 2, 1, 'expected ARR'),
+    expansionArr: readFormula(workpaper, sheet, 3, 1, 'expansion ARR'),
+    targetGap: readFormula(workpaper, sheet, 4, 1, 'target gap'),
+  };
+}
+
+function readNumber(workpaper, sheet, row, col, label) {
+  const cell = workpaper.getCellValue({ sheet, row, col });
+  if (!cell || typeof cell !== 'object' || !('value' in cell) || typeof cell.value !== 'number') {
+    throw new Error('Expected ' + label + ' to be a number, received ' + JSON.stringify(cell));
+  }
+  return Math.round(cell.value * 100) / 100;
+}
+
+function readFormula(workpaper, sheet, row, col, label) {
+  const formula = workpaper.getCellFormula({ sheet, row, col });
+  if (formula === undefined) {
+    throw new Error('Expected ' + label + ' to be a formula');
+  }
+  return formula;
+}
+
+function sameJson(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+`;
+
+async function run() {
+  if (!process.env.E2B_API_KEY) {
+    throw new Error('Set E2B_API_KEY in .env before running this example.');
+  }
+
+  console.log('Creating E2B sandbox...');
+  const sandbox = await Sandbox.create({ timeoutMs: 600_000 });
+
+  try {
+    console.log('Preparing WorkPaper verification script...');
+    await sandbox.commands.run(`mkdir -p ${workdir}`);
+    await sandbox.files.write(`${workdir}/workpaper-proof.mjs`, proofScript);
+
+    console.log('Installing @bilig/workpaper@0.107.8 inside the sandbox...');
+    await sandbox.commands.run('npm init -y >/dev/null && npm install @bilig/workpaper@0.107.8 >/dev/null', {
+      cwd: workdir,
+      timeoutMs: 120_000,
+    });
+
+    console.log('Running formula readback proof...');
+    const result = await sandbox.commands.run('node workpaper-proof.mjs', {
+      cwd: workdir,
+      timeoutMs: 120_000,
+    });
+
+    console.log(result.stdout.trim());
+  } finally {
+    console.log('Cleaning up sandbox...');
+    await sandbox.kill();
+  }
+}
+
+run().catch((error) => {
+  console.error('Failed to run Bilig WorkPaper formula readback example:', error);
+  process.exit(1);
+});

--- a/examples/bilig-workpaper-formula-readback-js/index.ts
+++ b/examples/bilig-workpaper-formula-readback-js/index.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import { Sandbox } from 'e2b';
 
 const workdir = '/tmp/bilig-workpaper-formula-readback';
+const workpaperVersion = '0.130.7';
 
 const proofScript = String.raw`
 import {
@@ -140,8 +141,8 @@ async function run() {
     await sandbox.commands.run(`mkdir -p ${workdir}`);
     await sandbox.files.write(`${workdir}/workpaper-proof.mjs`, proofScript);
 
-    console.log('Installing @bilig/workpaper@0.107.8 inside the sandbox...');
-    await sandbox.commands.run('npm init -y >/dev/null && npm install @bilig/workpaper@0.107.8 >/dev/null', {
+    console.log(`Installing @bilig/workpaper@${workpaperVersion} inside the sandbox...`);
+    await sandbox.commands.run(`npm init -y >/dev/null && npm install @bilig/workpaper@${workpaperVersion} >/dev/null`, {
       cwd: workdir,
       timeoutMs: 120_000,
     });

--- a/examples/bilig-workpaper-formula-readback-js/index.ts
+++ b/examples/bilig-workpaper-formula-readback-js/index.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { Sandbox } from 'e2b';
 
 const workdir = '/tmp/bilig-workpaper-formula-readback';
-const workpaperVersion = '0.131.2';
+const workpaperVersion = '0.131.3';
 
 const proofScript = String.raw`
 import {

--- a/examples/bilig-workpaper-formula-readback-js/index.ts
+++ b/examples/bilig-workpaper-formula-readback-js/index.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { Sandbox } from 'e2b';
 
 const workdir = '/tmp/bilig-workpaper-formula-readback';
-const workpaperVersion = '0.154.0';
+const workpaperVersion = '0.157.0';
 
 const proofScript = String.raw`
 import {

--- a/examples/bilig-workpaper-formula-readback-js/index.ts
+++ b/examples/bilig-workpaper-formula-readback-js/index.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { Sandbox } from 'e2b';
 
 const workdir = '/tmp/bilig-workpaper-formula-readback';
-const workpaperVersion = '0.131.3';
+const workpaperVersion = '0.154.0';
 
 const proofScript = String.raw`
 import {

--- a/examples/bilig-workpaper-formula-readback-js/index.ts
+++ b/examples/bilig-workpaper-formula-readback-js/index.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { Sandbox } from 'e2b';
 
 const workdir = '/tmp/bilig-workpaper-formula-readback';
-const workpaperVersion = '0.131.1';
+const workpaperVersion = '0.131.2';
 
 const proofScript = String.raw`
 import {

--- a/examples/bilig-workpaper-formula-readback-js/index.ts
+++ b/examples/bilig-workpaper-formula-readback-js/index.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { Sandbox } from 'e2b';
 
 const workdir = '/tmp/bilig-workpaper-formula-readback';
-const workpaperVersion = '0.130.7';
+const workpaperVersion = '0.131.1';
 
 const proofScript = String.raw`
 import {

--- a/examples/bilig-workpaper-formula-readback-js/package-lock.json
+++ b/examples/bilig-workpaper-formula-readback-js/package-lock.json
@@ -1,0 +1,978 @@
+{
+  "name": "bilig-workpaper-formula-readback-js",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bilig-workpaper-formula-readback-js",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.5",
+        "e2b": "^2.21.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.16.6",
+        "tsx": "^4.7.3",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
+      "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0-rc.3.tgz",
+      "integrity": "sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0",
+        "@connectrpc/connect": "2.0.0-rc.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dockerfile-ast": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.1.tgz",
+      "integrity": "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/e2b": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/e2b/-/e2b-2.21.0.tgz",
+      "integrity": "sha512-rXZX5KpGGjOe21ZDlL29hZfkHUb74ociUwrgf6jD3K+xrAeTFpoIU0ItlLDtu8ihWRIp9ld473RgtSbZLqJpig==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.6.2",
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-web": "2.0.0-rc.3",
+        "chalk": "^5.3.0",
+        "compare-versions": "^6.1.0",
+        "dockerfile-ast": "^0.7.1",
+        "glob": "^11.1.0",
+        "openapi-fetch": "^0.14.1",
+        "platform": "^1.3.6",
+        "tar": "^7.5.11",
+        "undici": "^7.25.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/openapi-fetch": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz",
+      "integrity": "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/examples/bilig-workpaper-formula-readback-js/package.json
+++ b/examples/bilig-workpaper-formula-readback-js/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "bilig-workpaper-formula-readback-js",
+  "version": "1.0.0",
+  "description": "Run Bilig WorkPaper formula readback inside an E2B sandbox",
+  "type": "module",
+  "main": "index.ts",
+  "scripts": {
+    "start": "tsx index.ts",
+    "test": "echo \"No tests configured for this example\""
+  },
+  "keywords": ["e2b", "bilig", "workpaper", "spreadsheet", "formula", "agent"],
+  "license": "MIT",
+  "author": {
+    "name": "FoundryLabs, Inc.",
+    "email": "hello@e2b.dev",
+    "url": "https://e2b.dev"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "e2b": "^2.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.6",
+    "tsx": "^4.7.3",
+    "typescript": "^5.4.5"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a TypeScript cookbook example that runs a Bilig WorkPaper formula-readback check inside an E2B sandbox.

The example installs `@bilig/workpaper@0.157.0` inside the sandbox, edits an input cell, recalculates dependent formula cells, and verifies that exported WorkPaper JSON restores to the same computed result.

## Why

Spreadsheet agents often need formula logic without driving Excel, LibreOffice, or a browser UI. This gives E2B users a small isolated pattern they can adapt for agent workflows that need formula write/readback.

## Validation

- `npm install` in `examples/bilig-workpaper-formula-readback-js`
- `npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck index.ts`
- `npm run test` in `examples/bilig-workpaper-formula-readback-js`
- `git diff --check`
- `npm view @bilig/workpaper version` returned `0.157.0`
- `npm exec --yes --package @bilig/workpaper@latest -- bilig-evaluate --door agent-mcp --json` returned `verified: true` on `@bilig/workpaper@0.157.0`

The public evaluator verified 8 MCP tools, `Inputs!B3` editing, expected ARR changing from `60000` to `96000`, JSON persistence, restart readback at `96000`, and package versions `@bilig/workpaper@0.157.0` / `xlsx-formula-recalc@0.157.0`.

I did not run the live sandbox example here because this local shell does not have an `E2B_API_KEY` configured.

## Notes

CLA is signed for this account.
