### PR TITLE
docs(readme): add UTM tracking to e2b.dev links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Example code and guides for building with [E2B SDK](https://github.com/e2b-dev/e2b).
 
-Read more about E2B on the [E2B website](https://e2b.dev) and the official [E2B documentation](https://e2b.dev/docs).
+Read more about E2B on the [E2B website](https://e2b.dev/?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=e2b-cookbook) and the official [E2B documentation](https://e2b.dev/docs?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=e2b-cookbook).
 
 ## Examples
 


### PR DESCRIPTION
Adds UTM parameters to the e2b.dev link(s) in the README so GitHub-referral traffic is attributed per repo.

`utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=<repo>`

Applies to apex e2b.dev links (root and subpaths). Subdomains and already-tagged links are untouched, and URL anchors are preserved.