### PR TITLE
Add Crabbox E2B warm-box example

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,27 @@ Read more about E2B on the [E2B website](https://e2b.dev/?utm_source=github&utm_
   </tbody>
 </table>
 
+**Remote execution integrations**
+
+<table>
+  <thead>
+    <tr>
+      <th>Integration</th>
+      <th>Description</th>
+      <th>Python</th>
+      <th>TypeScript</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/openclaw/crabbox">Crabbox</a></td>
+      <td>Warm one E2B sandbox, sync local changes, and rerun a test suite on the same lease</td>
+      <td><a href="./examples/crabbox-e2b-python">Python</a></td>
+      <td>-</td>
+    </tr>
+  </tbody>
+</table>
+
 **Model Context Protocol (MCP)**
 
 <table>
@@ -255,6 +276,7 @@ Read more about E2B on the [E2B website](https://e2b.dev/?utm_source=github&utm_
 - How to run Playwright in E2B - [TypeScript](./examples/playwright-in-e2b)
 - Map custom subdomains to your sandboxes - [TypeScript](./examples/custom-sandbox-domain-proxy)
 - Feedback analyst agent on Flue, publishing an HTML report from a sandbox - [TypeScript](./examples/flue-feedback-analyst-js)
+- Warm an E2B sandbox and rerun tests after adding a local regression case - [Python](./examples/crabbox-e2b-python)
 
 ## Running the examples as a test suite
 

--- a/examples/crabbox-e2b-python/.crabbox.yaml
+++ b/examples/crabbox-e2b-python/.crabbox.yaml
@@ -1,0 +1,10 @@
+provider: e2b
+target: linux
+
+e2b:
+  template: base
+  workdir: crabbox
+
+sync:
+  include:
+    - examples/crabbox-e2b-python

--- a/examples/crabbox-e2b-python/.env.example
+++ b/examples/crabbox-e2b-python/.env.example
@@ -1,0 +1,2 @@
+# Crabbox's E2B provider reads this variable from the shell.
+E2B_API_KEY=

--- a/examples/crabbox-e2b-python/README.md
+++ b/examples/crabbox-e2b-python/README.md
@@ -1,0 +1,62 @@
+# Warm-box test loop with Crabbox + E2B (Python)
+
+This example uses [Crabbox](https://github.com/openclaw/crabbox) to warm one E2B sandbox and reuse it for an iterative test loop. The first run syncs the current Git workset and executes the complete suite. The demo then adds a local regression fixture and runs the focused regression test on the same lease before cleaning everything up.
+
+The only credential is an E2B API key. Crabbox owns the warm lease, workset sync, command orchestration, and streamed output; E2B provides the isolated Linux runtime without Docker or SSH setup.
+
+## What the demo does
+
+1. Warms an E2B `base` sandbox with a unique Crabbox slug.
+2. Syncs this example and runs the complete Python test suite.
+3. Adds a local enterprise-support regression fixture.
+4. Resyncs the working tree and reruns the focused regression test on the same warm sandbox.
+5. Removes the temporary fixture and stops the lease, including when a test fails.
+
+## Setup
+
+Install the Crabbox CLI and verify it is available on your `PATH`:
+
+```bash
+brew install openclaw/tap/crabbox
+crabbox --version
+```
+
+Copy the environment template, add an [E2B API key](https://e2b.dev/docs/getting-started/api-key), and load it into the current shell:
+
+```bash
+cd examples/crabbox-e2b-python
+cp .env.example .env
+# Edit .env and set E2B_API_KEY=e2b_...
+set -a
+source .env
+set +a
+```
+
+Install the dependency-free project environment and run its local checks:
+
+```bash
+uv sync
+uv run python -m unittest discover -s tests -v
+```
+
+## Run the warm-box demo
+
+```bash
+uv run python main.py
+```
+
+`main.py` sets this nested example as `CRABBOX_CONFIG`, creates a unique lease name, and runs the equivalent lifecycle:
+
+```bash
+crabbox warmup --provider e2b --e2b-template base --slug <lease>
+crabbox run --provider e2b --id <lease> --shell '<full test command>'
+# Add one local regression fixture.
+crabbox run --provider e2b --id <lease> --shell '<focused regression test>'
+crabbox stop --provider e2b <lease>
+```
+
+Both test commands use the same `--id`, so the second run reuses the already-running E2B sandbox instead of provisioning another one. The temporary regression fixture is a nonignored local file, which makes it part of Crabbox's Git-managed workset for the second sync.
+
+The `.crabbox.yaml` sync include keeps uploads scoped to this example inside the cookbook monorepo. Replace `e2b.template` with a custom E2B template when a real test suite needs additional system dependencies.
+
+A live run creates an E2B sandbox. The driver always attempts `crabbox stop` in a `finally` block, but `crabbox list --provider e2b` can be used to inspect any lease left after a machine or network interruption.

--- a/examples/crabbox-e2b-python/demo/enterprise-regression.json
+++ b/examples/crabbox-e2b-python/demo/enterprise-regression.json
@@ -1,0 +1,9 @@
+{
+  "name": "enterprise rollout blocker",
+  "ticket": {
+    "severity": "high",
+    "account_tier": "enterprise",
+    "affected_users": 25
+  },
+  "expected_queue": "priority"
+}

--- a/examples/crabbox-e2b-python/fixtures/regression-security.json
+++ b/examples/crabbox-e2b-python/fixtures/regression-security.json
@@ -1,0 +1,9 @@
+{
+  "name": "security disclosure",
+  "ticket": {
+    "severity": "security",
+    "account_tier": "free",
+    "affected_users": 1
+  },
+  "expected_queue": "priority"
+}

--- a/examples/crabbox-e2b-python/main.py
+++ b/examples/crabbox-e2b-python/main.py
@@ -1,0 +1,157 @@
+"""Run two test passes on one warm E2B sandbox through Crabbox."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from uuid import uuid4
+
+EXAMPLE_RELATIVE_DIRECTORY = Path("examples/crabbox-e2b-python")
+FULL_TEST_COMMAND = (
+    "cd examples/crabbox-e2b-python && "
+    "python3 -m unittest discover -s tests -v"
+)
+FOCUSED_TEST_COMMAND = (
+    "cd examples/crabbox-e2b-python && "
+    "python3 -m unittest "
+    "tests.test_support_router.SupportRouterTests.test_regression_fixtures -v"
+)
+
+CommandRunner = Callable[..., subprocess.CompletedProcess[object]]
+
+
+def _require_api_key(environment: Mapping[str, str]) -> None:
+    if not (
+        environment.get("E2B_API_KEY")
+        or environment.get("CRABBOX_E2B_API_KEY")
+    ):
+        raise RuntimeError(
+            "Missing E2B_API_KEY. Copy .env.example to .env and load it "
+            "into the current shell."
+        )
+
+
+def run_demo(
+    *,
+    repo_root: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    command_runner: CommandRunner = subprocess.run,
+    crabbox_binary: str | None = None,
+    lease: str | None = None,
+) -> None:
+    """Warm one sandbox, run twice on it, and always attempt cleanup."""
+    root = repo_root or Path(__file__).resolve().parents[2]
+    example_directory = root / EXAMPLE_RELATIVE_DIRECTORY
+    environment = dict(os.environ if environ is None else environ)
+    _require_api_key(environment)
+
+    binary = crabbox_binary or shutil.which("crabbox")
+    if not binary:
+        raise RuntimeError(
+            "Crabbox is not installed. Run `brew install openclaw/tap/crabbox`."
+        )
+
+    config_path = example_directory / ".crabbox.yaml"
+    source_fixture = example_directory / "demo" / "enterprise-regression.json"
+    if not config_path.is_file() or not source_fixture.is_file():
+        raise RuntimeError("Run the demo from a complete e2b-cookbook checkout.")
+
+    lease_id = lease or f"warm-tests-{uuid4().hex[:8]}"
+    regression_fixture = (
+        example_directory / "fixtures" / f"regression-{lease_id}.json"
+    )
+    if regression_fixture.exists():
+        raise RuntimeError(f"Refusing to overwrite {regression_fixture}")
+
+    environment["CRABBOX_CONFIG"] = str(config_path)
+    warmup_started = False
+
+    try:
+        print(f"\n1/3 Warming E2B sandbox: {lease_id}")
+        warmup_started = True
+        command_runner(
+            [
+                binary,
+                "warmup",
+                "--provider",
+                "e2b",
+                "--e2b-template",
+                "base",
+                "--slug",
+                lease_id,
+            ],
+            cwd=root,
+            env=environment,
+            check=True,
+        )
+
+        print("\n2/3 Running the complete suite on the warm sandbox")
+        command_runner(
+            [
+                binary,
+                "run",
+                "--provider",
+                "e2b",
+                "--id",
+                lease_id,
+                "--shell",
+                FULL_TEST_COMMAND,
+            ],
+            cwd=root,
+            env=environment,
+            check=True,
+        )
+
+        shutil.copyfile(source_fixture, regression_fixture)
+        print(
+            "\nAdded local regression fixture: "
+            f"{regression_fixture.relative_to(root)}"
+        )
+        print("3/3 Resyncing and rerunning the focused test on the same sandbox")
+        command_runner(
+            [
+                binary,
+                "run",
+                "--provider",
+                "e2b",
+                "--id",
+                lease_id,
+                "--shell",
+                FOCUSED_TEST_COMMAND,
+            ],
+            cwd=root,
+            env=environment,
+            check=True,
+        )
+    finally:
+        regression_fixture.unlink(missing_ok=True)
+        if warmup_started:
+            print(f"\nStopping E2B sandbox: {lease_id}")
+            try:
+                result = command_runner(
+                    [binary, "stop", "--provider", "e2b", lease_id],
+                    cwd=root,
+                    env=environment,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    print(
+                        "Crabbox could not confirm cleanup. Inspect remaining "
+                        "leases with `crabbox list --provider e2b`."
+                    )
+            except OSError as error:
+                print(f"Crabbox cleanup could not run: {error}")
+
+
+def main() -> None:
+    try:
+        run_demo()
+    except RuntimeError as error:
+        raise SystemExit(str(error)) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/crabbox-e2b-python/pyproject.toml
+++ b/examples/crabbox-e2b-python/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "crabbox-e2b-python"
+version = "0.1.0"
+description = "Reuse one warm E2B sandbox for an iterative Crabbox test loop"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []

--- a/examples/crabbox-e2b-python/support_router.py
+++ b/examples/crabbox-e2b-python/support_router.py
@@ -1,0 +1,24 @@
+"""Route support tickets into standard or priority review queues."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def route_ticket(ticket: Mapping[str, object]) -> str:
+    """Return the queue for one support ticket."""
+    severity = str(ticket.get("severity", "")).casefold()
+    account_tier = str(ticket.get("account_tier", "")).casefold()
+
+    try:
+        affected_users = int(ticket.get("affected_users", 0))
+    except (TypeError, ValueError) as error:
+        raise ValueError("affected_users must be an integer") from error
+
+    if severity in {"critical", "security"}:
+        return "priority"
+
+    if account_tier == "enterprise" and affected_users >= 20:
+        return "priority"
+
+    return "standard"

--- a/examples/crabbox-e2b-python/tests/__init__.py
+++ b/examples/crabbox-e2b-python/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Crabbox E2B warm-sandbox example."""

--- a/examples/crabbox-e2b-python/tests/test_demo.py
+++ b/examples/crabbox-e2b-python/tests/test_demo.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+from main import EXAMPLE_RELATIVE_DIRECTORY, run_demo
+
+
+@dataclass(frozen=True)
+class CommandCall:
+    argv: list[str]
+    cwd: Path
+    environment: dict[str, str]
+    check: bool
+
+
+class RecordingCommands:
+    def __init__(
+        self,
+        regression_fixture: Path,
+        *,
+        fail_on_run: int | None = None,
+    ) -> None:
+        self.regression_fixture = regression_fixture
+        self.fail_on_run = fail_on_run
+        self.calls: list[CommandCall] = []
+        self.fixture_presence_during_runs: list[bool] = []
+        self.run_count = 0
+
+    def __call__(
+        self,
+        argv: list[str],
+        *,
+        cwd: Path,
+        env: dict[str, str],
+        check: bool,
+    ) -> subprocess.CompletedProcess[Any]:
+        self.calls.append(CommandCall(argv, cwd, dict(env), check))
+
+        if argv[1] == "run":
+            self.run_count += 1
+            self.fixture_presence_during_runs.append(
+                self.regression_fixture.exists()
+            )
+            if self.fail_on_run == self.run_count:
+                raise subprocess.CalledProcessError(1, argv)
+
+        return subprocess.CompletedProcess(argv, 0)
+
+
+class WarmBoxDemoTests(unittest.TestCase):
+    def _prepare_checkout(self, root: Path, lease: str) -> Path:
+        example = root / EXAMPLE_RELATIVE_DIRECTORY
+        (example / "demo").mkdir(parents=True)
+        (example / "fixtures").mkdir()
+        (example / ".crabbox.yaml").write_text(
+            "provider: e2b\n",
+            encoding="utf-8",
+        )
+        (example / "demo" / "enterprise-regression.json").write_text(
+            '{"expected_queue":"priority"}\n',
+            encoding="utf-8",
+        )
+        return example / "fixtures" / f"regression-{lease}.json"
+
+    def test_reuses_one_lease_and_syncs_the_local_regression(self) -> None:
+        lease = "warm-tests-unit"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            regression_fixture = self._prepare_checkout(root, lease)
+            commands = RecordingCommands(regression_fixture)
+
+            with redirect_stdout(StringIO()):
+                run_demo(
+                    repo_root=root,
+                    environ={"E2B_API_KEY": "e2b_test"},
+                    command_runner=commands,
+                    crabbox_binary="crabbox",
+                    lease=lease,
+                )
+
+            self.assertEqual(
+                [call.argv[1] for call in commands.calls],
+                ["warmup", "run", "run", "stop"],
+            )
+            self.assertEqual(
+                commands.fixture_presence_during_runs,
+                [False, True],
+            )
+            run_leases = [
+                call.argv[call.argv.index("--id") + 1]
+                for call in commands.calls
+                if call.argv[1] == "run"
+            ]
+            self.assertEqual(run_leases, [lease, lease])
+            self.assertFalse(regression_fixture.exists())
+            self.assertEqual(
+                commands.calls[0].environment["CRABBOX_CONFIG"],
+                str(root / EXAMPLE_RELATIVE_DIRECTORY / ".crabbox.yaml"),
+            )
+
+    def test_stops_the_lease_and_removes_the_fixture_after_failure(self) -> None:
+        lease = "warm-tests-failure"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            regression_fixture = self._prepare_checkout(root, lease)
+            commands = RecordingCommands(regression_fixture, fail_on_run=2)
+
+            with redirect_stdout(StringIO()):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    run_demo(
+                        repo_root=root,
+                        environ={"E2B_API_KEY": "e2b_test"},
+                        command_runner=commands,
+                        crabbox_binary="crabbox",
+                        lease=lease,
+                    )
+
+            self.assertEqual(commands.calls[-1].argv[1], "stop")
+            self.assertFalse(commands.calls[-1].check)
+            self.assertFalse(regression_fixture.exists())
+
+    def test_requires_an_e2b_api_key(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "Missing E2B_API_KEY"):
+            run_demo(
+                environ={},
+                crabbox_binary="crabbox",
+            )

--- a/examples/crabbox-e2b-python/tests/test_support_router.py
+++ b/examples/crabbox-e2b-python/tests/test_support_router.py
@@ -1,0 +1,41 @@
+import json
+import unittest
+from pathlib import Path
+
+from support_router import route_ticket
+
+EXAMPLE_DIRECTORY = Path(__file__).resolve().parents[1]
+
+
+class SupportRouterTests(unittest.TestCase):
+    def test_routes_a_normal_ticket_to_the_standard_queue(self) -> None:
+        ticket = {
+            "severity": "medium",
+            "account_tier": "pro",
+            "affected_users": 3,
+        }
+
+        self.assertEqual(route_ticket(ticket), "standard")
+
+    def test_routes_a_critical_ticket_to_the_priority_queue(self) -> None:
+        ticket = {
+            "severity": "critical",
+            "account_tier": "free",
+            "affected_users": 1,
+        }
+
+        self.assertEqual(route_ticket(ticket), "priority")
+
+    def test_regression_fixtures(self) -> None:
+        fixtures = sorted(
+            (EXAMPLE_DIRECTORY / "fixtures").glob("regression-*.json")
+        )
+        self.assertTrue(fixtures, "expected at least one regression fixture")
+
+        for fixture in fixtures:
+            payload = json.loads(fixture.read_text(encoding="utf-8"))
+            with self.subTest(fixture=fixture.name, case=payload["name"]):
+                self.assertEqual(
+                    route_ticket(payload["ticket"]),
+                    payload["expected_queue"],
+                )

--- a/examples/crabbox-e2b-python/uv.lock
+++ b/examples/crabbox-e2b-python/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "crabbox-e2b-python"
+version = "0.1.0"
+source = { virtual = "." }

--- a/tests/run-examples.ts
+++ b/tests/run-examples.ts
@@ -122,6 +122,11 @@ const scripts: {
 //   mcp-browserbase-js (BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID, GEMINI_API_KEY)
 //   mcp-research-agent-js (EXA_API_KEY)
 //   stirrup-python (its own auth header)
+// Orchestrates the external Crabbox CLI, which creates and reuses its own E2B
+// sandbox. Running it here would nest a live sandbox inside this runner, and the
+// suite does not install Crabbox. Its unit tests cover command order and cleanup;
+// the real provider lifecycle remains a separate, explicitly approved smoke:
+//   crabbox-e2b-python
 // Runs a long-lived agent/server process rather than a script that exits, so
 // this runner can only ever time out on them:
 //   flue-feedback-analyst-js, vercel-eve-feedback-analyst-js,


### PR DESCRIPTION
## Summary

- add a Python cookbook example that warms one E2B sandbox through Crabbox
- reuse the same lease for a full test run and a focused regression rerun after resyncing a new local fixture
- guarantee fixture removal and lease cleanup, including failure paths
- document the integration in the cookbook index and keep the live Crabbox lifecycle out of the root example runner

## Why

Crabbox supports E2B as a remote execution provider. This example shows the practical warm-box development loop: sync the current workset, run tests, add a regression case, and rerun only the focused test without provisioning another sandbox.

The sync whitelist uses the example directory as a root-relative include. This ensures nested tests and fixtures are transferred while keeping the upload scoped to this example.

## Validation

- `uv run python -m unittest discover -s tests -v` — 6 passed
- `crabbox sync-plan --json` — 12 files, guardrail status `ok`
- live E2B smoke with Crabbox v0.43.0 — full suite passed, then the focused regression passed on the same lease after resync
- `crabbox list --provider e2b` — no remaining leases after cleanup
- `git diff --check`
