### PR TITLE
Add Vercel AI SDK sandbox provider example (JavaScript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ Read more about E2B on the [E2B website](https://e2b.dev/?utm_source=github&utm_
       <td><a href="./examples/nextjs-code-interpreter">TypeScript</a></td>
     </tr>
     <tr>
+    <td>▲ <a href="https://ai-sdk.dev">Vercel AI SDK</a></td>
+      <td>AI SDK sandbox provider: sandboxed tools via restricted sessions, and harness coding agents (Claude Code, Codex) running inside E2B</td>
+      <td>-</td>
+      <td><a href="./examples/vercel-ai-sdk-sandbox-js">TypeScript</a></td>
+    </tr>
+    <tr>
     <td>▲ <a href="https://eve.dev/docs">Vercel eve</a></td>
       <td>Feedback analyst agent whose sandbox backend is E2B, publishing an HTML report from the sandbox</td>
       <td>-</td>

--- a/examples/vercel-ai-sdk-sandbox-js/.env.example
+++ b/examples/vercel-ai-sdk-sandbox-js/.env.example
@@ -1,0 +1,8 @@
+# https://e2b.dev/dashboard
+E2B_API_KEY=
+
+# https://platform.openai.com — used by the harness example (Pi + gpt-5.6-luna)
+# and by the tool example when ANTHROPIC_API_KEY is not set
+OPENAI_API_KEY=
+# https://console.anthropic.com — optional; the tool example prefers it when set
+ANTHROPIC_API_KEY=

--- a/examples/vercel-ai-sdk-sandbox-js/.env.example
+++ b/examples/vercel-ai-sdk-sandbox-js/.env.example
@@ -1,8 +1,8 @@
 # https://e2b.dev/dashboard
 E2B_API_KEY=
 
-# https://platform.openai.com — used by the harness example (Pi + gpt-5.6-luna)
-# and by the tool example when ANTHROPIC_API_KEY is not set
-OPENAI_API_KEY=
-# https://console.anthropic.com — optional; the tool example prefers it when set
+# Set at least one LLM provider key — both scripts prefer Anthropic when set
+# https://console.anthropic.com
 ANTHROPIC_API_KEY=
+# https://platform.openai.com
+OPENAI_API_KEY=

--- a/examples/vercel-ai-sdk-sandbox-js/README.md
+++ b/examples/vercel-ai-sdk-sandbox-js/README.md
@@ -1,0 +1,69 @@
+# Vercel AI SDK on E2B Sandboxes (JavaScript)
+
+Two ways to run [AI SDK](https://ai-sdk.dev) agents on E2B, both through
+[`@e2b/ai-sdk-sandbox`](https://www.npmjs.com/package/@e2b/ai-sdk-sandbox) —
+the E2B provider for AI SDK 7's sandbox interface.
+
+## 1. A sandboxed tool (`src/tool.ts`)
+
+A regular `generateText` agent with a `bash` tool whose commands run in an
+isolated E2B sandbox instead of your machine. `session.restricted()` is the
+security boundary: the tool gets file I/O and command execution, but nothing
+that could stop the sandbox or change its network policy.
+
+```ts
+const session = await createE2BSandbox({}).createSession()
+const sandbox = session.restricted()
+
+const result = await generateText({
+  model,
+  tools: {
+    bash: tool({
+      inputSchema: z.object({ command: z.string() }),
+      execute: async ({ command }) => sandbox.run({ command }),
+    }),
+  },
+  prompt: '…',
+})
+```
+
+## 2. A coding agent on the sandbox (`src/harness.ts`)
+
+The [AI SDK harness](https://ai-sdk.dev/v7/docs/ai-sdk-harnesses/overview)
+runs the [Pi](https://github.com/earendil-works/pi) coding agent against the
+E2B sandbox: Pi runs as an in-process library, and every tool it uses —
+`bash`, `read`, `write`, `grep` — executes inside the sandbox, never on your
+machine.
+
+```ts
+const agent = new HarnessAgent({
+  harness: createPi({ auth: 'openai', model: 'openai/gpt-5.6-luna' }),
+  sandbox: createE2BSandbox({ timeoutMs: 10 * 60 * 1000 }),
+})
+```
+
+Other harness adapters (`@ai-sdk/harness-claude-code`,
+`@ai-sdk/harness-codex`) plug into the same `sandbox` option.
+
+## How to run
+
+**1. Set the API keys**
+
+Copy `.env.example` to `.env` and fill in `E2B_API_KEY` plus an LLM provider
+key (`ANTHROPIC_API_KEY` or `OPENAI_API_KEY` — the scripts pick whichever is
+set, for both the model and the harness adapter).
+
+**2. Install dependencies**
+
+```bash
+npm install
+```
+
+**3. Run**
+
+```bash
+npm run start           # sandboxed tool
+npm run start:harness   # coding agent inside the sandbox
+```
+
+Both destroy their sandboxes at the end.

--- a/examples/vercel-ai-sdk-sandbox-js/README.md
+++ b/examples/vercel-ai-sdk-sandbox-js/README.md
@@ -37,7 +37,7 @@ machine.
 
 ```ts
 const agent = new HarnessAgent({
-  harness: createPi({ auth: 'openai', model: 'openai/gpt-5.6-luna' }),
+  harness: createPi({ auth, model }), // e.g. 'openai' + 'openai/gpt-5.6-luna'
   sandbox: createE2BSandbox({ timeoutMs: 10 * 60 * 1000 }),
 })
 ```

--- a/examples/vercel-ai-sdk-sandbox-js/package.json
+++ b/examples/vercel-ai-sdk-sandbox-js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "vercel-ai-sdk-sandbox",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Vercel AI SDK agents on E2B sandboxes via @e2b/ai-sdk-sandbox",
+  "scripts": {
+    "start": "tsx src/tool.ts",
+    "start:harness": "tsx src/harness.ts"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.0",
+    "@ai-sdk/harness": "^1.0.73",
+    "@ai-sdk/harness-pi": "^1.0.75",
+    "@ai-sdk/openai": "^3.0.0",
+    "@e2b/ai-sdk-sandbox": "^0.1.0",
+    "ai": "^7.0.66",
+    "dotenv": "^17.4.2",
+    "tsx": "^4.19.4",
+    "zod": "^3.25.76"
+  }
+}

--- a/examples/vercel-ai-sdk-sandbox-js/src/harness.ts
+++ b/examples/vercel-ai-sdk-sandbox-js/src/harness.ts
@@ -6,11 +6,13 @@ import { HarnessAgent } from '@ai-sdk/harness/agent'
 import { createPi } from '@ai-sdk/harness-pi'
 import { createE2BSandbox } from '@e2b/ai-sdk-sandbox'
 
+// Pick the provider from whichever key is set; Pi reads the key from the env.
+const [auth, model] = process.env.ANTHROPIC_API_KEY
+  ? (['anthropic', 'anthropic/claude-sonnet-5'] as const)
+  : (['openai', 'openai/gpt-5.6-luna'] as const)
+
 const agent = new HarnessAgent({
-  harness: createPi({
-    auth: 'openai', // reads OPENAI_API_KEY from the environment
-    model: 'openai/gpt-5.6-luna',
-  }),
+  harness: createPi({ auth, model }),
   sandbox: createE2BSandbox({ timeoutMs: 10 * 60 * 1000 }),
 })
 

--- a/examples/vercel-ai-sdk-sandbox-js/src/harness.ts
+++ b/examples/vercel-ai-sdk-sandbox-js/src/harness.ts
@@ -1,0 +1,26 @@
+// The Pi coding agent driving an E2B sandbox via the AI SDK harness. Pi runs
+// as an in-process library (no bridge to set up); every tool it uses — bash,
+// read, write, grep — executes inside the E2B sandbox, never on your machine.
+import 'dotenv/config'
+import { HarnessAgent } from '@ai-sdk/harness/agent'
+import { createPi } from '@ai-sdk/harness-pi'
+import { createE2BSandbox } from '@e2b/ai-sdk-sandbox'
+
+const agent = new HarnessAgent({
+  harness: createPi({
+    auth: 'openai', // reads OPENAI_API_KEY from the environment
+    model: 'openai/gpt-5.6-luna',
+  }),
+  sandbox: createE2BSandbox({ timeoutMs: 10 * 60 * 1000 }),
+})
+
+const session = await agent.createSession()
+try {
+  const result = await agent.generate({
+    session,
+    prompt: 'Write fizzbuzz.js and run it with node. Show me the output.',
+  })
+  console.log('\n' + result.text)
+} finally {
+  await session.destroy()
+}

--- a/examples/vercel-ai-sdk-sandbox-js/src/tool.ts
+++ b/examples/vercel-ai-sdk-sandbox-js/src/tool.ts
@@ -1,0 +1,43 @@
+// An AI SDK agent with a sandboxed shell tool: the model writes commands,
+// they execute in an isolated E2B sandbox — never on your machine.
+// `restricted()` is the security boundary: the tool gets file I/O and
+// command execution, but nothing that could stop the sandbox or change its
+// network policy.
+import 'dotenv/config'
+import { generateText, stepCountIs, tool } from 'ai'
+import { anthropic } from '@ai-sdk/anthropic'
+import { openai } from '@ai-sdk/openai'
+import { createE2BSandbox } from '@e2b/ai-sdk-sandbox'
+import { z } from 'zod'
+
+const model = process.env.ANTHROPIC_API_KEY
+  ? anthropic('claude-sonnet-5')
+  : openai('gpt-5.2')
+
+const session = await createE2BSandbox({}).createSession()
+const sandbox = session.restricted()
+
+try {
+  const result = await generateText({
+    model,
+    stopWhen: stepCountIs(8),
+    prompt:
+      'Which Linux kernel is this machine running, and how many prime numbers are there below 10000? ' +
+      'Use the sandbox for both — write and run a script for the primes. Quote the exact outputs.',
+    tools: {
+      bash: tool({
+        description: 'Run a shell command in an isolated E2B sandbox',
+        inputSchema: z.object({ command: z.string() }),
+        execute: async ({ command }) => {
+          console.log(`$ ${command}`)
+          const { stdout, stderr, exitCode } = await sandbox.run({ command })
+          return { stdout, stderr, exitCode }
+        },
+      }),
+    },
+  })
+
+  console.log('\n' + result.text)
+} finally {
+  await session.destroy?.()
+}

--- a/examples/vercel-ai-sdk-sandbox-js/src/tool.ts
+++ b/examples/vercel-ai-sdk-sandbox-js/src/tool.ts
@@ -12,7 +12,7 @@ import { z } from 'zod'
 
 const model = process.env.ANTHROPIC_API_KEY
   ? anthropic('claude-sonnet-5')
-  : openai('gpt-5.2')
+  : openai('gpt-5.6-luna')
 
 const session = await createE2BSandbox({}).createSession()
 const sandbox = session.restricted()


### PR DESCRIPTION
## What

Adds `examples/vercel-ai-sdk-sandbox-js`, plus a row in the root README's AI-frameworks table. Two entry points through [`@e2b/ai-sdk-sandbox`](https://github.com/e2b-dev/ai-sdk-sandbox), the E2B provider for AI SDK 7's sandbox interface:

**1. A sandboxed tool** (`npm run start`) — a `generateText` agent with a `bash` tool whose commands run in an isolated E2B sandbox via `session.restricted()`, the tool-safe boundary (file I/O + exec, no lifecycle or network controls).

**2. A coding agent on the sandbox** (`npm run start:harness`) — the [Pi](https://github.com/earendil-works/pi) coding agent (`gpt-5.6-luna`) driving the E2B sandbox via the AI SDK harness: Pi runs in-process and every tool it uses executes inside the sandbox. The claude-code/codex adapters plug into the same `sandbox` option.

## Verified

Both entry points ran live end to end (tool agent answered kernel + prime-count correctly from real sandbox execution; Pi wrote and ran fizzbuzz through the sandbox).

## Note

`@e2b/ai-sdk-sandbox` is not yet published to npm (verified here against a local pack of e2b-dev/ai-sdk-sandbox with #3 applied — the AI SDK 7 stable update the adapters need). `package-lock.json` is intentionally absent until the package is live; happy to add it right after the publish.
