### PR TITLE
Add Hermes incident playbook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Read more about E2B on the [E2B website](https://e2b.dev/?utm_source=github&utm_
       <td>-</td>
     </tr>
     <tr>
+      <td><a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a></td>
+      <td>Learn an incident-triage skill in one sandbox and apply it in a fresh session</td>
+      <td><a href="./examples/hermes-incident-playbook-python">Python</a></td>
+      <td>-</td>
+    </tr>
+    <tr>
     <td>▲ Vercel AI SDK</td>
       <td>Next.js + AI SDK + Code Interpreter</td>
       <td>-</td>
@@ -296,6 +302,7 @@ Read more about E2B on the [E2B website](https://e2b.dev/?utm_source=github&utm_
 - Map custom subdomains to your sandboxes - [TypeScript](./examples/custom-sandbox-domain-proxy)
 - Feedback analyst agent on Flue, publishing an HTML report from a sandbox - [TypeScript](./examples/flue-feedback-analyst-js)
 - Warm an E2B sandbox and rerun tests after adding a local regression case - [Python](./examples/crabbox-e2b-python)
+- Teach Hermes an incident-triage playbook and reuse it in a fresh session - [Python](./examples/hermes-incident-playbook-python)
 
 ## Running the examples as a test suite
 

--- a/examples/hermes-incident-playbook-python/.env.example
+++ b/examples/hermes-incident-playbook-python/.env.example
@@ -1,0 +1,6 @@
+E2B_API_KEY=your_e2b_api_key
+HERMES_TEMPLATE=hermes
+OPENROUTER_API_KEY=your_openrouter_api_key
+HERMES_PROVIDER=openrouter
+HERMES_MODEL=anthropic/claude-sonnet-4.6
+HERMES_PROVIDER_KEY_ENV=OPENROUTER_API_KEY

--- a/examples/hermes-incident-playbook-python/README.md
+++ b/examples/hermes-incident-playbook-python/README.md
@@ -1,0 +1,60 @@
+# Self-improving incident playbook with Hermes + E2B (Python)
+
+This example runs [Hermes Agent](https://github.com/NousResearch/hermes-agent) inside one E2B sandbox for two independent incident investigations. During the first investigation, Hermes uses terminal and file tools to analyze evidence, writes a report, saves a compact memory, and turns the successful procedure into a reusable skill. A fresh Hermes session then preloads that skill and applies it to a different incident.
+
+The scenario is designed around Hermes' closed learning loop rather than a generic agent prompt. E2B contains the autonomous tool calls and preserves the workspace, `~/.hermes/memories`, sessions, and user-created skills for the lifetime of the sandbox.
+
+## What the demo does
+
+1. Creates a sandbox from the pre-built E2B `hermes` template.
+2. Uploads an incident runbook and two synthetic checkout incidents.
+3. Starts a headless Hermes session that investigates latency and creates the `incident-triage` skill.
+4. Verifies the skill exists under `~/.hermes/skills`.
+5. Starts a fresh session with `--skills incident-triage` and investigates a release-correlated error spike.
+6. Keeps both reports in the sandbox workspace until the demo cleans up.
+
+The first incident points to upstream payment latency rather than the nearby checkout release. The second incident points to a release-specific regression. This makes the learned playbook apply decision rules instead of repeating the same answer.
+
+## Setup
+
+Copy the environment template, add your E2B and OpenRouter API keys, and load it into the current shell.
+
+```bash
+cd examples/hermes-incident-playbook-python
+cp .env.example .env
+# Edit .env with real credentials.
+set -a
+source .env
+set +a
+```
+
+Install the project and run its non-live unit tests.
+
+```bash
+uv sync
+uv run python -m unittest discover -s tests -v
+```
+
+`HERMES_PROVIDER`, `HERMES_MODEL`, and `HERMES_PROVIDER_KEY_ENV` make the demo model-agnostic. For example, set `HERMES_PROVIDER=anthropic`, `HERMES_MODEL=claude-sonnet-4-6`, `HERMES_PROVIDER_KEY_ENV=ANTHROPIC_API_KEY`, and export that key to use Anthropic directly. `HERMES_TEMPLATE` can point the demo at a tagged or private template during development; it defaults to `hermes`.
+
+## Run the playbook
+
+```bash
+uv run python main.py
+```
+
+The driver runs the equivalent Hermes lifecycle inside one sandbox:
+
+```bash
+hermes chat -Q --yolo --provider <provider> --model <model> \
+  --toolsets terminal,file,skills,memory \
+  -q "Investigate the first incident and create the incident-triage skill"
+
+hermes chat -Q --yolo --provider <provider> --model <model> \
+  --toolsets terminal,file,skills,memory --skills incident-triage \
+  -q "Apply the learned skill to the next incident"
+```
+
+`-Q` keeps stdout concise for automation. `--yolo` lets Hermes use tools without waiting for an interactive approval; those actions remain contained inside E2B. Sandboxes can reach the open internet by default, so use [network rules](https://e2b.dev/docs/network/internet-access) when processing untrusted input or tightly scoped credentials.
+
+The live demo creates an E2B sandbox and makes provider inference calls. `main.py` always kills the sandbox in a `finally` block, including when Hermes or the provider fails.

--- a/examples/hermes-incident-playbook-python/README.md
+++ b/examples/hermes-incident-playbook-python/README.md
@@ -4,6 +4,8 @@ This example runs [Hermes Agent](https://github.com/NousResearch/hermes-agent) i
 
 The scenario is designed around Hermes' closed learning loop rather than a generic agent prompt. E2B contains the autonomous tool calls and preserves the workspace, `~/.hermes/memories`, sessions, and user-created skills for the lifetime of the sandbox.
 
+For a shorter introduction to the same learn-then-reuse workflow, see the [Hermes Agent guide](https://e2b.dev/docs/agents/hermes#teach-hermes-a-reusable-skill).
+
 ## What the demo does
 
 1. Creates a sandbox from the pre-built E2B `hermes` template.

--- a/examples/hermes-incident-playbook-python/incidents/checkout-errors.json
+++ b/examples/hermes-incident-playbook-python/incidents/checkout-errors.json
@@ -1,0 +1,27 @@
+{
+  "incident_id": "INC-1047",
+  "service": "checkout",
+  "started_at": "2026-08-18T11:05:00Z",
+  "release": "checkout-2026.08.18.2",
+  "baseline": {
+    "p95_ms": 245,
+    "error_rate": 0.005
+  },
+  "current": {
+    "p95_ms": 270,
+    "error_rate": 0.091
+  },
+  "errors_by_endpoint": {
+    "/checkout/confirm": 438,
+    "/checkout/preview": 3
+  },
+  "errors_by_release": {
+    "checkout-2026.08.18.1": 4,
+    "checkout-2026.08.18.2": 437
+  },
+  "dependencies": {
+    "payments_p95_ms": 190,
+    "inventory_p95_ms": 92
+  },
+  "release_started_at": "2026-08-18T10:58:00Z"
+}

--- a/examples/hermes-incident-playbook-python/incidents/checkout-latency.json
+++ b/examples/hermes-incident-playbook-python/incidents/checkout-latency.json
@@ -1,0 +1,19 @@
+{
+  "incident_id": "INC-1042",
+  "service": "checkout",
+  "started_at": "2026-08-18T08:12:00Z",
+  "release": "checkout-2026.08.18.1",
+  "baseline": {
+    "p95_ms": 240,
+    "error_rate": 0.006
+  },
+  "current": {
+    "p95_ms": 1840,
+    "error_rate": 0.018
+  },
+  "dependencies": {
+    "payments_p95_ms": 1610,
+    "inventory_p95_ms": 95
+  },
+  "release_started_at": "2026-08-18T07:30:00Z"
+}

--- a/examples/hermes-incident-playbook-python/main.py
+++ b/examples/hermes-incident-playbook-python/main.py
@@ -1,0 +1,198 @@
+"""Teach Hermes an incident playbook, then reuse it in a fresh session."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, Protocol
+
+EXAMPLE_DIRECTORY = Path(__file__).resolve().parent
+SANDBOX_WORKSPACE = "/home/user/incident-workspace"
+SKILL_NAME = "incident-triage"
+KEY_NAME_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+
+class CommandResult(Protocol):
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class SandboxLike(Protocol):
+    commands: Any
+    files: Any
+
+    def kill(self) -> None: ...
+
+
+SandboxFactory = Callable[..., SandboxLike]
+
+
+def _settings(environment: Mapping[str, str]) -> tuple[str, str, dict[str, str]]:
+    if not environment.get("E2B_API_KEY"):
+        raise RuntimeError(
+            "Missing E2B_API_KEY. Copy .env.example to .env and load it."
+        )
+
+    provider = environment.get("HERMES_PROVIDER", "openrouter")
+    model = environment.get(
+        "HERMES_MODEL",
+        "anthropic/claude-sonnet-4.6",
+    )
+    key_name = environment.get(
+        "HERMES_PROVIDER_KEY_ENV",
+        "OPENROUTER_API_KEY",
+    )
+    if not KEY_NAME_PATTERN.fullmatch(key_name):
+        raise RuntimeError("HERMES_PROVIDER_KEY_ENV must be an environment name.")
+
+    key = environment.get(key_name)
+    if not key:
+        raise RuntimeError(f"Missing {key_name} for the Hermes model provider.")
+
+    return provider, model, {key_name: key}
+
+
+def _hermes_command(
+    *,
+    provider: str,
+    model: str,
+    prompt: str,
+    skill: str | None = None,
+) -> str:
+    arguments = [
+        "hermes",
+        "chat",
+        "-Q",
+        "--yolo",
+        "--provider",
+        provider,
+        "--model",
+        model,
+        "--toolsets",
+        "terminal,file,skills,memory",
+    ]
+    if skill:
+        arguments.extend(["--skills", skill])
+    arguments.extend(["-q", prompt])
+    return shlex.join(arguments)
+
+
+def _run_agent(sandbox: SandboxLike, command: str) -> str:
+    result: CommandResult = sandbox.commands.run(command, timeout=600)
+    if result.exit_code != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"Hermes failed: {detail}")
+    return result.stdout
+
+
+def run_demo(
+    *,
+    environ: Mapping[str, str] | None = None,
+    sandbox_factory: SandboxFactory | None = None,
+    example_directory: Path = EXAMPLE_DIRECTORY,
+) -> None:
+    """Run two independent Hermes sessions in one persistent E2B sandbox."""
+    environment = os.environ if environ is None else environ
+    provider, model, provider_env = _settings(environment)
+    template = environment.get("HERMES_TEMPLATE", "hermes")
+
+    if sandbox_factory is None:
+        from e2b import Sandbox
+
+        sandbox_factory = Sandbox.create
+
+    sandbox = sandbox_factory(
+        template,
+        envs=provider_env,
+        timeout=900,
+    )
+    try:
+        setup = sandbox.commands.run(
+            f"mkdir -p {SANDBOX_WORKSPACE}/incidents {SANDBOX_WORKSPACE}/reports"
+        )
+        if setup.exit_code != 0:
+            raise RuntimeError(f"Could not prepare workspace: {setup.stderr}")
+
+        sandbox.files.write(
+            f"{SANDBOX_WORKSPACE}/runbook.md",
+            (example_directory / "runbook.md").read_text(encoding="utf-8"),
+        )
+        first_incident = example_directory / "incidents" / "checkout-latency.json"
+        sandbox.files.write(
+            f"{SANDBOX_WORKSPACE}/incidents/{first_incident.name}",
+            first_incident.read_text(encoding="utf-8"),
+        )
+
+        first_prompt = f"""
+You are the on-call investigator. Read {SANDBOX_WORKSPACE}/runbook.md and
+{SANDBOX_WORKSPACE}/incidents/checkout-latency.json. Use terminal and file tools
+to investigate the evidence. Write a concise report to
+{SANDBOX_WORKSPACE}/reports/checkout-latency.md. Then use skill_manage to create
+a reusable skill named {SKILL_NAME} from the successful procedure, including
+verification and rollback decision rules. Save one compact memory noting where
+this service's incident inputs and reports live. Do not modify the input files.
+""".strip()
+
+        print("\n1/2 Investigating the first incident and learning a playbook")
+        first_response = _run_agent(
+            sandbox,
+            _hermes_command(
+                provider=provider,
+                model=model,
+                prompt=first_prompt,
+            ),
+        )
+        print(first_response.strip())
+
+        skill_check = sandbox.commands.run(
+            "find \"$HOME/.hermes/skills\" -type f "
+            f"-path '*/{SKILL_NAME}/SKILL.md' -print -quit"
+        )
+        if skill_check.exit_code != 0 or not skill_check.stdout.strip():
+            raise RuntimeError(
+                f"Hermes did not create the expected {SKILL_NAME} skill."
+            )
+
+        next_incident = example_directory / "incidents" / "checkout-errors.json"
+        sandbox.files.write(
+            f"{SANDBOX_WORKSPACE}/incidents/{next_incident.name}",
+            next_incident.read_text(encoding="utf-8"),
+        )
+
+        second_prompt = f"""
+Start a fresh investigation using the preloaded {SKILL_NAME} skill and your
+persistent memory. Analyze
+{SANDBOX_WORKSPACE}/incidents/checkout-errors.json and write the evidence,
+conclusion, and next action to
+{SANDBOX_WORKSPACE}/reports/checkout-errors.md. Do not modify the input file.
+""".strip()
+
+        print("\n2/2 Applying the learned playbook to a new incident")
+        second_response = _run_agent(
+            sandbox,
+            _hermes_command(
+                provider=provider,
+                model=model,
+                prompt=second_prompt,
+                skill=SKILL_NAME,
+            ),
+        )
+        print(second_response.strip())
+        print(f"\nReports remain in {SANDBOX_WORKSPACE}/reports until cleanup.")
+    finally:
+        sandbox.kill()
+
+
+def main() -> None:
+    try:
+        run_demo()
+    except RuntimeError as error:
+        raise SystemExit(str(error)) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hermes-incident-playbook-python/main.py
+++ b/examples/hermes-incident-playbook-python/main.py
@@ -9,10 +9,18 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, Protocol
 
+from e2b import AuthenticationException, CommandExitException, SandboxException
+
 EXAMPLE_DIRECTORY = Path(__file__).resolve().parent
 SANDBOX_WORKSPACE = "/home/user/incident-workspace"
 SKILL_NAME = "incident-triage"
 KEY_NAME_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
+AGENT_TIMEOUT = 600
+# Allow two sequential agent turns plus workspace setup and file transfers.
+SANDBOX_TIMEOUT = 1500
+RUN_METADATA = {"example": "hermes-incident-playbook-python"}
+# Hermes still writes tool diffs to stdout under -Q, so bound what a failure reports.
+DETAIL_TAIL = 600
 
 
 class CommandResult(Protocol):
@@ -81,11 +89,29 @@ def _hermes_command(
     return shlex.join(arguments)
 
 
+def _tail(stream: str, limit: int = DETAIL_TAIL) -> str:
+    text = (stream or "").strip()
+    return text if len(text) <= limit else "..." + text[-limit:]
+
+
+def _failure_detail(error: CommandExitException) -> str:
+    # Hermes writes its real failure to stdout and its warnings to stderr, and
+    # the template always emits a startup warning, so reporting stderr alone
+    # would surface that warning and hide the cause. Even under -Q, Hermes
+    # still prints tool diffs, so keep the tail of each stream: the failure is
+    # the last thing written, not the first.
+    parts = [tail for tail in (_tail(error.stdout), _tail(error.stderr)) if tail]
+    return " | ".join(parts) or str(error)
+
+
 def _run_agent(sandbox: SandboxLike, command: str) -> str:
-    result: CommandResult = sandbox.commands.run(command, timeout=600)
-    if result.exit_code != 0:
-        detail = result.stderr.strip() or result.stdout.strip()
-        raise RuntimeError(f"Hermes failed: {detail}")
+    try:
+        result: CommandResult = sandbox.commands.run(
+            command,
+            timeout=AGENT_TIMEOUT,
+        )
+    except CommandExitException as error:
+        raise RuntimeError(f"Hermes failed: {_failure_detail(error)}") from error
     return result.stdout
 
 
@@ -108,14 +134,19 @@ def run_demo(
     sandbox = sandbox_factory(
         template,
         envs=provider_env,
-        timeout=900,
+        metadata=RUN_METADATA,
+        timeout=SANDBOX_TIMEOUT,
     )
     try:
-        setup = sandbox.commands.run(
-            f"mkdir -p {SANDBOX_WORKSPACE}/incidents {SANDBOX_WORKSPACE}/reports"
-        )
-        if setup.exit_code != 0:
-            raise RuntimeError(f"Could not prepare workspace: {setup.stderr}")
+        try:
+            sandbox.commands.run(
+                f"mkdir -p {SANDBOX_WORKSPACE}/incidents "
+                f"{SANDBOX_WORKSPACE}/reports"
+            )
+        except CommandExitException as error:
+            raise RuntimeError(
+                f"Could not prepare workspace: {_failure_detail(error)}"
+            ) from error
 
         sandbox.files.write(
             f"{SANDBOX_WORKSPACE}/runbook.md",
@@ -148,11 +179,16 @@ this service's incident inputs and reports live. Do not modify the input files.
         )
         print(first_response.strip())
 
-        skill_check = sandbox.commands.run(
-            "find \"$HOME/.hermes/skills\" -type f "
-            f"-path '*/{SKILL_NAME}/SKILL.md' -print -quit"
-        )
-        if skill_check.exit_code != 0 or not skill_check.stdout.strip():
+        try:
+            skill_check = sandbox.commands.run(
+                "find \"$HOME/.hermes/skills\" -type f "
+                f"-path '*/{SKILL_NAME}/SKILL.md' -print -quit"
+            )
+        except CommandExitException as error:
+            raise RuntimeError(
+                f"Hermes did not create the expected {SKILL_NAME} skill."
+            ) from error
+        if not skill_check.stdout.strip():
             raise RuntimeError(
                 f"Hermes did not create the expected {SKILL_NAME} skill."
             )
@@ -190,7 +226,10 @@ conclusion, and next action to
 def main() -> None:
     try:
         run_demo()
-    except RuntimeError as error:
+    except (RuntimeError, SandboxException, AuthenticationException) as error:
+        # Every failure the SDK can raise here is an environment or provider
+        # problem, not a bug worth a traceback: a bad key, an unreachable
+        # template, a killed sandbox, or a turn that outran its timeout.
         raise SystemExit(str(error)) from error
 
 

--- a/examples/hermes-incident-playbook-python/pyproject.toml
+++ b/examples/hermes-incident-playbook-python/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "hermes-incident-playbook-python"
+version = "0.1.0"
+description = "Teach Hermes an incident-triage skill and reuse it inside E2B"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "e2b>=2.39,<3",
+]

--- a/examples/hermes-incident-playbook-python/runbook.md
+++ b/examples/hermes-incident-playbook-python/runbook.md
@@ -1,0 +1,7 @@
+# Checkout incident triage
+
+1. Establish the affected endpoint, release, and time window.
+2. Compare application errors with upstream dependency latency.
+3. Prefer evidence from the incident payload over assumptions.
+4. Recommend rollback only when the release correlates with the failure.
+5. Record evidence, conclusion, and next action in the incident report.

--- a/examples/hermes-incident-playbook-python/tests/__init__.py
+++ b/examples/hermes-incident-playbook-python/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Hermes incident playbook example."""

--- a/examples/hermes-incident-playbook-python/tests/test_main.py
+++ b/examples/hermes-incident-playbook-python/tests/test_main.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+
+from main import SKILL_NAME, run_demo
+
+
+@dataclass
+class RecordedResult:
+    exit_code: int = 0
+    stdout: str = "ok\n"
+    stderr: str = ""
+
+
+class RecordingCommands:
+    def __init__(self, *, fail_first_agent: bool = False) -> None:
+        self.commands: list[str] = []
+        self.fail_first_agent = fail_first_agent
+        self.agent_runs = 0
+
+    def run(self, command: str, **_: object) -> RecordedResult:
+        self.commands.append(command)
+        if command.startswith("hermes chat"):
+            self.agent_runs += 1
+            if self.fail_first_agent and self.agent_runs == 1:
+                return RecordedResult(1, "", "provider failed")
+        if command.startswith("find "):
+            return RecordedResult(
+                stdout=f"/home/user/.hermes/skills/{SKILL_NAME}/SKILL.md\n"
+            )
+        return RecordedResult()
+
+
+class RecordingFiles:
+    def __init__(self) -> None:
+        self.writes: dict[str, str] = {}
+
+    def write(self, path: str, content: str) -> None:
+        self.writes[path] = content
+
+
+class RecordingSandbox:
+    def __init__(self, *, fail_first_agent: bool = False) -> None:
+        self.commands = RecordingCommands(fail_first_agent=fail_first_agent)
+        self.files = RecordingFiles()
+        self.killed = False
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+class RecordingFactory:
+    def __init__(self, sandbox: RecordingSandbox) -> None:
+        self.sandbox = sandbox
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def __call__(self, template: str, **options: object) -> RecordingSandbox:
+        self.calls.append((template, options))
+        return self.sandbox
+
+
+class HermesIncidentPlaybookTests(unittest.TestCase):
+    def _example(self, root: Path) -> Path:
+        example = root / "example"
+        (example / "incidents").mkdir(parents=True)
+        (example / "runbook.md").write_text("triage steps\n", encoding="utf-8")
+        (example / "incidents" / "checkout-latency.json").write_text(
+            '{"incident_id":"INC-1"}\n', encoding="utf-8"
+        )
+        (example / "incidents" / "checkout-errors.json").write_text(
+            '{"incident_id":"INC-2"}\n', encoding="utf-8"
+        )
+        return example
+
+    def test_learns_and_reuses_the_incident_skill(self) -> None:
+        sandbox = RecordingSandbox()
+        factory = RecordingFactory(sandbox)
+        environment = {
+            "E2B_API_KEY": "e2b_test",
+            "OPENROUTER_API_KEY": "or_test",
+            "HERMES_PROVIDER": "openrouter",
+            "HERMES_MODEL": "test/model",
+            "HERMES_TEMPLATE": "hermes:smoke",
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            with redirect_stdout(StringIO()):
+                run_demo(
+                    environ=environment,
+                    sandbox_factory=factory,
+                    example_directory=self._example(Path(directory)),
+                )
+
+        self.assertEqual(factory.calls[0][0], "hermes:smoke")
+        self.assertEqual(
+            factory.calls[0][1]["envs"],
+            {"OPENROUTER_API_KEY": "or_test"},
+        )
+        agent_commands = [
+            command
+            for command in sandbox.commands.commands
+            if command.startswith("hermes chat")
+        ]
+        self.assertEqual(len(agent_commands), 2)
+        self.assertIn("--yolo", agent_commands[0])
+        self.assertIn("--model test/model", agent_commands[0])
+        self.assertNotIn("--skills", agent_commands[0])
+        self.assertIn(f"--skills {SKILL_NAME}", agent_commands[1])
+        self.assertEqual(len(sandbox.files.writes), 3)
+        self.assertTrue(sandbox.killed)
+
+    def test_kills_the_sandbox_when_hermes_fails(self) -> None:
+        sandbox = RecordingSandbox(fail_first_agent=True)
+        factory = RecordingFactory(sandbox)
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(RuntimeError, "provider failed"):
+                with redirect_stdout(StringIO()):
+                    run_demo(
+                        environ={
+                            "E2B_API_KEY": "e2b_test",
+                            "OPENROUTER_API_KEY": "or_test",
+                        },
+                        sandbox_factory=factory,
+                        example_directory=self._example(Path(directory)),
+                    )
+
+        self.assertTrue(sandbox.killed)
+
+    def test_requires_e2b_and_provider_credentials(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "Missing E2B_API_KEY"):
+            run_demo(environ={}, sandbox_factory=RecordingFactory(RecordingSandbox()))
+
+        with self.assertRaisesRegex(RuntimeError, "Missing OPENROUTER_API_KEY"):
+            run_demo(
+                environ={"E2B_API_KEY": "e2b_test"},
+                sandbox_factory=RecordingFactory(RecordingSandbox()),
+            )

--- a/examples/hermes-incident-playbook-python/tests/test_main.py
+++ b/examples/hermes-incident-playbook-python/tests/test_main.py
@@ -7,7 +7,19 @@ from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
 
-from main import SKILL_NAME, run_demo
+from unittest.mock import patch
+
+from e2b import AuthenticationException, CommandExitException, TimeoutException
+
+from main import (
+    DETAIL_TAIL,
+    RUN_METADATA,
+    SANDBOX_TIMEOUT,
+    SKILL_NAME,
+    _failure_detail,
+    main,
+    run_demo,
+)
 
 
 @dataclass
@@ -18,9 +30,15 @@ class RecordedResult:
 
 
 class RecordingCommands:
-    def __init__(self, *, fail_first_agent: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        fail_first_agent: bool = False,
+        fail_skill_check: bool = False,
+    ) -> None:
         self.commands: list[str] = []
         self.fail_first_agent = fail_first_agent
+        self.fail_skill_check = fail_skill_check
         self.agent_runs = 0
 
     def run(self, command: str, **_: object) -> RecordedResult:
@@ -28,8 +46,20 @@ class RecordingCommands:
         if command.startswith("hermes chat"):
             self.agent_runs += 1
             if self.fail_first_agent and self.agent_runs == 1:
-                return RecordedResult(1, "", "provider failed")
+                raise CommandExitException(
+                    stdout="API call failed after 3 retries: provider failed",
+                    stderr="\u26a0 Deprecated .env settings detected",
+                    exit_code=1,
+                    error=None,
+                )
         if command.startswith("find "):
+            if self.fail_skill_check:
+                raise CommandExitException(
+                    stderr="skills directory missing",
+                    stdout="",
+                    exit_code=1,
+                    error=None,
+                )
             return RecordedResult(
                 stdout=f"/home/user/.hermes/skills/{SKILL_NAME}/SKILL.md\n"
             )
@@ -45,8 +75,16 @@ class RecordingFiles:
 
 
 class RecordingSandbox:
-    def __init__(self, *, fail_first_agent: bool = False) -> None:
-        self.commands = RecordingCommands(fail_first_agent=fail_first_agent)
+    def __init__(
+        self,
+        *,
+        fail_first_agent: bool = False,
+        fail_skill_check: bool = False,
+    ) -> None:
+        self.commands = RecordingCommands(
+            fail_first_agent=fail_first_agent,
+            fail_skill_check=fail_skill_check,
+        )
         self.files = RecordingFiles()
         self.killed = False
 
@@ -101,6 +139,8 @@ class HermesIncidentPlaybookTests(unittest.TestCase):
             factory.calls[0][1]["envs"],
             {"OPENROUTER_API_KEY": "or_test"},
         )
+        self.assertEqual(factory.calls[0][1]["metadata"], RUN_METADATA)
+        self.assertEqual(factory.calls[0][1]["timeout"], SANDBOX_TIMEOUT)
         agent_commands = [
             command
             for command in sandbox.commands.commands
@@ -131,6 +171,75 @@ class HermesIncidentPlaybookTests(unittest.TestCase):
                     )
 
         self.assertTrue(sandbox.killed)
+
+    def test_kills_the_sandbox_when_the_skill_check_fails(self) -> None:
+        sandbox = RecordingSandbox(fail_skill_check=True)
+        factory = RecordingFactory(sandbox)
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(RuntimeError, "did not create the expected"):
+                with redirect_stdout(StringIO()):
+                    run_demo(
+                        environ={
+                            "E2B_API_KEY": "e2b_test",
+                            "OPENROUTER_API_KEY": "or_test",
+                        },
+                        sandbox_factory=factory,
+                        example_directory=self._example(Path(directory)),
+                    )
+
+        self.assertTrue(sandbox.killed)
+
+    def test_surfaces_the_real_cause_not_just_the_startup_warning(self) -> None:
+        # The hermes template always writes a deprecation warning to stderr, so
+        # reporting stderr alone would hide the real failure on stdout.
+        sandbox = RecordingSandbox(fail_first_agent=True)
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(RuntimeError) as caught:
+                with redirect_stdout(StringIO()):
+                    run_demo(
+                        environ={
+                            "E2B_API_KEY": "e2b_test",
+                            "OPENROUTER_API_KEY": "or_test",
+                        },
+                        sandbox_factory=RecordingFactory(sandbox),
+                        example_directory=self._example(Path(directory)),
+                    )
+
+        message = str(caught.exception)
+        self.assertIn("API call failed after 3 retries", message)
+        self.assertIn("Deprecated .env settings", message)
+        self.assertTrue(sandbox.killed)
+
+    def test_bounds_a_noisy_failure_detail(self) -> None:
+        # Under -Q the real template still prints tool diffs to stdout, so a
+        # failed turn produced a ~4.5k-character message. The cause is the last
+        # thing written, so the tail is what has to survive truncation.
+        noise = "+ review diff line\n" * 400
+        error = CommandExitException(
+            stdout=noise + "API call failed after 3 retries: Gemini HTTP 503",
+            stderr="",
+            exit_code=1,
+            error=None,
+        )
+        detail = _failure_detail(error)
+        self.assertIn("Gemini HTTP 503", detail)
+        self.assertLessEqual(len(detail), DETAIL_TAIL + 3)
+        self.assertTrue(detail.startswith("..."))
+
+    def test_reports_sdk_failures_without_a_traceback(self) -> None:
+        # A bad key, an unreachable template, a killed sandbox, or a turn that
+        # outran its timeout must all exit with a message, not a traceback.
+        for error in (
+            TimeoutException("sandbox timed out"),
+            AuthenticationException("invalid api key"),
+        ):
+            with self.subTest(error=type(error).__name__):
+                with patch("main.run_demo", side_effect=error):
+                    with self.assertRaises(SystemExit) as caught:
+                        main()
+                self.assertEqual(str(caught.exception), str(error))
 
     def test_requires_e2b_and_provider_credentials(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "Missing E2B_API_KEY"):

--- a/examples/hermes-incident-playbook-python/uv.lock
+++ b/examples/hermes-incident-playbook-python/uv.lock
@@ -1,0 +1,382 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "bracex"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/01/5f394b8bcd6e5b92f73130990960423bbb19711f906bd9fe9ea5557c667c/bracex-3.0.1.tar.gz", hash = "sha256:4e38e32392e4a4780fe15d644bfc7c8514057cfc3861e060b11814ce829c25e4", size = 44019, upload-time = "2026-07-20T13:43:00.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl", hash = "sha256:6523ad83aeb5098a4ee597cff0f964442ff74e460bd3fafaffab6a013ff2288c", size = 11940, upload-time = "2026-07-20T13:42:59.268Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "connectrpc"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py" },
+    { name = "pyqwest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/b5/63e14ab9d4d4cc58818562db4120a35fa7454e3035633da41bdc6b712abd/connectrpc-0.11.1.tar.gz", hash = "sha256:18277f7838847b4271ca38d40c7d2387b5a2ea6a29f240689c19e1ec84aaff66", size = 46222, upload-time = "2026-07-15T06:33:31.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/ac/aa647675812cd075f2cb9acb00d62f4f2cbcbc6736049a62342b7371ce5b/connectrpc-0.11.1-py3-none-any.whl", hash = "sha256:8a52e2e92a485fa9681c1101a79a5ebeb31807e3ea3d5aabd41f484a6398bc7b", size = 64991, upload-time = "2026-07-15T06:33:29.396Z" },
+]
+
+[[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "connectrpc" },
+    { name = "dockerfile-parse" },
+    { name = "h2" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf-py" },
+    { name = "pyqwest" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/6e/6858328cca81501677264058dcd1c5c37ef05a758e346dec371dfc2e3698/e2b-2.40.0.tar.gz", hash = "sha256:e1b7f518bd86059cda6da3da86a481915f38e891f248b7e53c2fa2fcd6dc47bc", size = 210269, upload-time = "2026-08-18T12:56:30.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/5e/7b1bb151e44f426fed88134214d58e3cd2461510abc086789e9789ff73aa/e2b-2.40.0-py3-none-any.whl", hash = "sha256:7dd1026d5cab01b76aa0f162f1015173ed76484a7adab2fcd1f45505ddf5e36f", size = 371345, upload-time = "2026-08-18T12:56:32.228Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
+]
+
+[[package]]
+name = "hermes-incident-playbook-python"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "e2b" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "e2b", specifier = ">=2.39,<3" }]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "protobuf-py"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf-py-ext", marker = "(platform_machine == 'arm64' and platform_python_implementation == 'CPython' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation == 'CPython' and sys_platform == 'linux') or (platform_machine == 'AMD64' and platform_python_implementation == 'CPython' and sys_platform == 'win32') or (platform_machine == 'ARM64' and platform_python_implementation == 'CPython' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/ed/02fd902d9c51b7ff53dfc9a745eb11490722edfd30073af889e171f07b8e/protobuf_py-0.1.1.tar.gz", hash = "sha256:6bd08ac4d8f1661965bbe2685429d79043704cdd1ee720a7a89617331742240b", size = 133525, upload-time = "2026-06-24T19:02:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/00/1b3775aca1c70e3007e06ef5996f6bb9b3a32341eb0cce3ffb6effad8dec/protobuf_py-0.1.1-py3-none-any.whl", hash = "sha256:efc4f50f275ed6dae10a1f30bb81ad1a75368557b3ff22a532b7a472050368f1", size = 181656, upload-time = "2026-06-24T19:01:29.556Z" },
+]
+
+[[package]]
+name = "protobuf-py-ext"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/05/6dc9ccff1e8159eb9a144e6d3c4acfd2211cd4fcd20c34fe9155d17d6a7f/protobuf_py_ext-0.1.1.tar.gz", hash = "sha256:e85bfdfdb3ed50634db8ccc7429dd9286520109489c735463971a418707b4fef", size = 31912, upload-time = "2026-06-24T19:02:16.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/70/2b5d62a60a2e0d88ecde1ae98db3132bcd2672fb39c8d581b82b34ac0bd8/protobuf_py_ext-0.1.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:310039e03cb15181781a0b78017419f6d4ee302e988c3c70b87f1facdf05532d", size = 306008, upload-time = "2026-06-24T19:01:31.399Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d6/73c06bb4cac2e04c0adc154965fe8b6520224bd737fd7e73bba405056321/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89ec8348d1ba045f79b2fedd14e40cca36f2a41b52f2c4fdf55a60c58add2353", size = 314769, upload-time = "2026-06-24T19:01:32.89Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c5/e4e6bc6096b66d1c82639a1b501147f16ee65d32567304b987d002e2c666/protobuf_py_ext-0.1.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:182798e4861aba72d05855bd06febe4926aa7265e6f444a1b8af5252beee4f7e", size = 328122, upload-time = "2026-06-24T19:01:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/1d792a40d0f0a0f914f1dfa8bb5e9573ca0ecd5fe5cecf80d77193212abd/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9eb25c3a329c0551cc86b209a5e5d8ecb8d834b9924a3aa019377853a703b6d3", size = 492338, upload-time = "2026-06-24T19:01:36.103Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/5ad329223c905e5c530cae38ae24cde3584d8ab7e09457f2a01afce80e60/protobuf_py_ext-0.1.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aaecbde82bef10c7c40578cbb61b7a19896bf7fa450972050a3bb302acb7d5d6", size = 541578, upload-time = "2026-06-24T19:01:37.481Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c7/01bd8a8bfe2df4b07aafac12ccfb7b7ebe2303f65296a9e02fcafa28ff3e/protobuf_py_ext-0.1.1-cp310-abi3-win_amd64.whl", hash = "sha256:6b0c615c48e95acc53cf33e9310eeaff8b30d2d7555bf93e7bca8fb4f40e9a5c", size = 251319, upload-time = "2026-06-24T19:01:38.946Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/914065538b5db54b6a920b5af38c1ef142252ea1eea711820435fa259fac/protobuf_py_ext-0.1.1-cp310-abi3-win_arm64.whl", hash = "sha256:72956cd0af5dee24b41c6f5ba5e42622d17e6d555002b5efc1634e27a1446de2", size = 241635, upload-time = "2026-06-24T19:01:40.301Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/0b5d73cab815fd50615cb87a02e04e8332f9e27380c890aba1459cf7e919/protobuf_py_ext-0.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c6f0cd58620f415a3534d195358338f4999a774e12510f91c592b38d13d37388", size = 304903, upload-time = "2026-06-24T19:01:41.796Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/14c120b9ac36a0e11bb05e482fa6ae322de583a8e1068e4859035c289947/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21572764f625d829604fc4d83635f533f35775f11c6da142345b3f3c8d64bd09", size = 316148, upload-time = "2026-06-24T19:01:43.247Z" },
+    { url = "https://files.pythonhosted.org/packages/35/54/7c00a1a9783c3ba74f6b2f5d2f049f09037bbd489c465c09a34f32fb611b/protobuf_py_ext-0.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7f14f00c2678bfbe7ad46f057b9f9938c1677bcf39e405e163e272c6f9814b8", size = 326458, upload-time = "2026-06-24T19:01:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/0e/81fa50c0d6c4d664e5be6d0a3c4f2c7edfef87ab12d0bac764abca1f2955/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1610865622e2e27568277ca63d8d2d23dcc55eaa767398865c21539ddf4ce24d", size = 493596, upload-time = "2026-06-24T19:01:46.344Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/3183cf6e4de62846c20549654a1d573dae51ca06aaf7fed06accdfab74f6/protobuf_py_ext-0.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8995efba9476e1ea18ef9873306871dba697308994bc2766558fec3387acc3de", size = 539656, upload-time = "2026-06-24T19:01:48.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/6c/09841f3dbe7c3d4b3f2779f8f2832ac23fb96ac8ab71674e91af732cf9ff/protobuf_py_ext-0.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ba61d49dace8f874361583030a7c48139b42eb37c9ffbb1e7e8a227a51576f44", size = 305017, upload-time = "2026-06-24T19:01:49.84Z" },
+    { url = "https://files.pythonhosted.org/packages/52/43/e450b5e202f6715274acc9acd9f9769908cbdeab861a53c798fcbd467d35/protobuf_py_ext-0.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a9c2f026096ca4c595c89a297067ef371e241d3ff8e1f6d7c779aa8419cdca7", size = 316215, upload-time = "2026-06-24T19:01:51.249Z" },
+    { url = "https://files.pythonhosted.org/packages/97/5c/23e79b35f1b5755b9bdc0c0c9b8cd8abababaef1a1639608d8a96bb61a9d/protobuf_py_ext-0.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf78707a040b9294e5e1ec4a1875f0046acfe52e92150cea27de4e9fc9db39bb", size = 326419, upload-time = "2026-06-24T19:01:52.93Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/de/5493de0ec12920a3b1dd72608ce0c1e8cdb7e0eb9e87accaecc5216df29e/protobuf_py_ext-0.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ae4373845cbb85bdade3ef5368cc2f4b5f80bf173383afc1ab063f95644e5599", size = 493734, upload-time = "2026-06-24T19:01:54.301Z" },
+    { url = "https://files.pythonhosted.org/packages/98/89/31da55b414e6332aad11d858e9a86bd36fbb324f52fa3fc6d8f1c57840a9/protobuf_py_ext-0.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2a4cc478eef7a2acc1daaebcde479a3ac2396d47e6bdc7e776ca4c4147ba8b4c", size = 539703, upload-time = "2026-06-24T19:01:55.707Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/71/39f231838ef06476d46ac40dd814894277a732a3688c0a0c994850b3b62f/protobuf_py_ext-0.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:359dccdc1c3eafed2a913c570bb082b8df848a1d27d548ce8385f246a7d68be2", size = 302145, upload-time = "2026-06-24T19:01:57.116Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f1/01c81ff5f420600366a0e6a613ce2af20834534d2b3d7523f4f3b4ddb54f/protobuf_py_ext-0.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91c38b4a10a306366443273ee03ca554537a0965bf05b7ada8e7dbdee04cc93e", size = 314541, upload-time = "2026-06-24T19:01:58.745Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d8/1cbf5a0298ceddc0cdbb28bf1ecaf8bd3cff54ed4ced6a1392d5226172fc/protobuf_py_ext-0.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79eee3bcbb289d6ea114eb8fe3a1469c5b59bf53e207238469f567d9c53ba56f", size = 325092, upload-time = "2026-06-24T19:02:00.382Z" },
+    { url = "https://files.pythonhosted.org/packages/af/23/8b1694616044cbfec2d18d4c6fffb03e05089c8bdb5970c6bafd60cc7fd5/protobuf_py_ext-0.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:10992141a8282a71ac3e3530d1a489efb27618d84000b9a47918cf70e5816d9b", size = 491684, upload-time = "2026-06-24T19:02:01.862Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/99997a7a6cf6989c944d9183c5deb6a045c27460add0316c7b34763891b3/protobuf_py_ext-0.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4411ffe0e06a774b83c5c71c546ce097640a25f596c45f95f53d3e3148e3f22d", size = 538048, upload-time = "2026-06-24T19:02:03.362Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/9e99ecbb68e1d5b46016d821eb1cbba9a91e6b50e71e75faf0c1e6189f0d/protobuf_py_ext-0.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55a17d80ea419501ff221a6627523f38a431bb33e6aa3de81ae3a7f271c49c75", size = 296337, upload-time = "2026-06-24T19:02:04.787Z" },
+    { url = "https://files.pythonhosted.org/packages/af/f2/305338a28225fb54b28d6c3f5948109b9088b329a2b6f77ca610c2bdcd34/protobuf_py_ext-0.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbb518b5638403ceaa08ac4fc7dac626f45ed9b856b3517de3906cf3de4d632", size = 308961, upload-time = "2026-06-24T19:02:06.185Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f9/416103c93677ff2ea407704ea64fa6de9e700dc030c48360a182d91ce373/protobuf_py_ext-0.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a4adc65ab6a5e4885c67fc808bcacb83d755d05b566d312a0e10c2a873f2ad4", size = 321895, upload-time = "2026-06-24T19:02:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/83/eb3e81bb2f83834b7deff4cee2d56eeb1adcbc847492a56b7f910ab257db/protobuf_py_ext-0.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e97f45c49676efacfb8e95bfcb1a002bc337e618a6780be1e55df2ba5ebd2f1e", size = 486091, upload-time = "2026-06-24T19:02:09.243Z" },
+    { url = "https://files.pythonhosted.org/packages/99/96/bd88fca38556b3105e4dd41d6a176e31dcc583fe979e830aeedd2f8c20ee/protobuf_py_ext-0.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:53a6b3590f6aa7f97b8ed60f62fef9b096babfeae82f7283fd3a4c405827d4f8", size = 534582, upload-time = "2026-06-24T19:02:11.227Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pyqwest"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/59/97531fd9d0a06d54e84f5493775739b0c1d0d13ec704974d04fa423a3332/pyqwest-0.9.0.tar.gz", hash = "sha256:514dd0b37d7a1bcb978b5d6423d15f89cf7dcf8058ac2a37aa42cd30090de89e", size = 477462, upload-time = "2026-08-10T01:55:36.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/34/d556fa07d9bff21fc6c9c16738614c6336164b65d9ced1ce9f1c1044aaeb/pyqwest-0.9.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:517d2eb295d56ef1530cebe0cf290a66fa199c57955bd1c5f1dc592240fbb7d6", size = 5224594, upload-time = "2026-08-10T01:54:18.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3f/1d7d1a08ebf8838c0c85e99ab5db5c1aae457f76ee03b60c8f4fc4948e01/pyqwest-0.9.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:408dc692835363b6824bee61ee9e4c9a5bba9c08d75b903f82f9a802e41d1b30", size = 5100753, upload-time = "2026-08-10T01:54:20.669Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fe/22c4056b526baa4c2c953f4e99925ce0bb14e7747d66e6ac3448a34f76e5/pyqwest-0.9.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1abf1ab3a0c1b545651ab37a643acc7909c4e7644a63a2e4af36e3e230a0db5", size = 5619882, upload-time = "2026-08-10T01:54:22.468Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2c/8f1159a30bbc905b2fcbc386740a260e76ae64372feb263103438ef5201c/pyqwest-0.9.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b02e5c9ce57e079eb3716c464d3818ad2573d7743483c39526ad77ee95af806", size = 5564744, upload-time = "2026-08-10T01:54:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/fd/ff15034d7874fd208d606bd80c924fb0b1091db8159c892672168b656de1/pyqwest-0.9.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:98bdaa30a3a8d8c71506a33c084e485a243fbf51e77130bb39e0f249dd116142", size = 5779373, upload-time = "2026-08-10T01:54:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b5/eeafdeb65ad8fe9c39044aedcfc97610f4e5c7b5620ca9fe2d504f669108/pyqwest-0.9.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:10eba84f9d8512d23bd16dd60b1c77dab956470361559214981dda065df4ad1a", size = 5973306, upload-time = "2026-08-10T01:54:28.729Z" },
+    { url = "https://files.pythonhosted.org/packages/34/db/a8979dab5c591529f858d1505d09b3c8b6dec337921f15bed4858c55716e/pyqwest-0.9.0-cp310-abi3-win_amd64.whl", hash = "sha256:af4e859800b02cd1fcdd898af26a881c4a8ce9520f71f6cb0a5403523d2cbbdf", size = 4834706, upload-time = "2026-08-10T01:54:30.335Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9e/d070ca1ce3c202952770436172889a4b0556a564a490baf726f7bb895eba/pyqwest-0.9.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:abe322cc1b63947b493bc06028615e0d5de655928159227aab64f60a0eb0e27d", size = 5244745, upload-time = "2026-08-10T01:54:32.257Z" },
+    { url = "https://files.pythonhosted.org/packages/41/97/ebded0bb35a79f51bb2d1519e34922d79c8825f9e71b696bb20f387a08c2/pyqwest-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c6b2dc6a9c583859d031941e1041b8e711afe0ad4c130628207731cef2b1a486", size = 5101044, upload-time = "2026-08-10T01:54:34.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/2c/a7f117e793b4e27642807bf7230b9fa297ff1e1ac489fc260fc3d4350ae4/pyqwest-0.9.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:551e47714da72a72939958029eb37a754cecd974344471c4a2038583a66a5396", size = 5630841, upload-time = "2026-08-10T01:54:35.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/be47fc141529941352a848cd77da581803137b733993a51bf464f2c48915/pyqwest-0.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3be3d38ccdab3077bf1cfe90c346ce927f9b49c56dcdf20e060f5f2502d01021", size = 5572909, upload-time = "2026-08-10T01:54:37.653Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/fd/703635e12710ce7ef5e961f5e1b22c609aecc8f07eedd79477b48d1edb74/pyqwest-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:45d9d424da878b22604799d1ce2a0a5df054924487ee5a851ad08025e2076e5c", size = 5794049, upload-time = "2026-08-10T01:54:39.363Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/941aad56b108c743df9d41e124be82ecb6be0eba1007e945b6a39f5dd1a0/pyqwest-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e4420adcd2b756da706b31a04f095a521f6e440dab284b7a1b46c76e048c1f78", size = 5974542, upload-time = "2026-08-10T01:54:41.202Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/86/8445fe05b47322047347464a909ae95dba023bf8409b9967f66bda2905ad/pyqwest-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:25734bd9798bbfaa53c83d395649dd9ea9a791a64b9848734955cb78ad52c832", size = 4847034, upload-time = "2026-08-10T01:54:42.899Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/92/013fc3c94f0dc4eeca556431797da477d76ad43d69134837ba149468dcc3/pyqwest-0.9.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6e4c2afe6c7293d9e42cfdb0489b0b5f64002159c2dc9c45d9322c1b4ffb42cd", size = 5244793, upload-time = "2026-08-10T01:54:44.891Z" },
+    { url = "https://files.pythonhosted.org/packages/48/61/c685e0c595f3f1b7842a776c48aaf2b3f47270a61672967d9d38f7c5e7f6/pyqwest-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:67f153b94dfbb9aeabc38f20a1bada1acfd9361bec12db86268bd951be35a154", size = 5100715, upload-time = "2026-08-10T01:54:46.777Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a1/a28b2cd704d7dd37043f1e6b398798576c12293f3efae84f00e7f6a5625c/pyqwest-0.9.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9942ffa243c8c2243e3ce04e3e3ec9b4c119346c963fd0051cd989f0defecf6", size = 5628787, upload-time = "2026-08-10T01:54:48.488Z" },
+    { url = "https://files.pythonhosted.org/packages/36/31/6255c7f17cd00e39f1c4df3003cea2d2d087e483fb4c49a6535307cd21e0/pyqwest-0.9.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f8f9c880c19826fead1838e12b042865b15df3ec844928cc74188a8b740f761", size = 5571946, upload-time = "2026-08-10T01:54:50.181Z" },
+    { url = "https://files.pythonhosted.org/packages/37/71/344738bdb38bddbc07cb29e5b1287c08db9e53d6b322581492571bdef748/pyqwest-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:56040761f6ca7abb036c7d288863bf143a9b166d824d98a604908ef20c6906e0", size = 5792872, upload-time = "2026-08-10T01:54:52.045Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ee/c5c74e3afb6dd0a25bca23bb4757d1a7135fab09a0a054036e837d49dd11/pyqwest-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:02a51df744521e45eb5379bc325b91de4512ec64a9f4aba3248f9166ec4e5b88", size = 5974192, upload-time = "2026-08-10T01:54:53.818Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/08/302960836e3e43ca3051313ee3b767534d1610bd3b8033c7bbad41b06e1b/pyqwest-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:e9a0e3123aee446d5f6e57c43cae87b4dab4b1af3fa970d114d74d5d4b9d075c", size = 4847050, upload-time = "2026-08-10T01:54:56.155Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/3e/a36940844325fbc59adf92116d3bcd1155cc2c72d1a390880886ca492bb4/pyqwest-0.9.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:fdab21bbedff4a21209135423f5f54f287a01dd6143cbd7aeab63d5d8c889654", size = 5246741, upload-time = "2026-08-10T01:54:57.697Z" },
+    { url = "https://files.pythonhosted.org/packages/41/8d/efb9741449a81f2489f6929a7691a2145662c3650e06bcb139c64f543d0a/pyqwest-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:21a04ddf4497ef3c7fe36cdc473c094999b7710005d38bd8a0dfd4a3feace12f", size = 5102423, upload-time = "2026-08-10T01:54:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a8/0b667cf9c07e62861cfe24c09ad30357a9c2a0fc3863cfc5610af5b66e3e/pyqwest-0.9.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8c51c1a27ea529fffab90c127a045f0dfe1abc54d5b9ad5f4165e954439c9b2", size = 5627663, upload-time = "2026-08-10T01:55:01.036Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7c/1f88be3d35afe92b79e361aa40faf3904e3a7852e8638a9d3d5c00891ab3/pyqwest-0.9.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10f283ffc40a2774e0dc8fbb47e4a8f9f8a698a99feae3bf4ad75b340c98031b", size = 5572750, upload-time = "2026-08-10T01:55:03.163Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3e/98c1e151772e77dcf00cb8b1c070f2c8edcb15fe12fdee30c1022006ca8e/pyqwest-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1f73d4a8e75b5860741fbd0623a0ce792a53336dbfec5f34736004acd5446843", size = 5790615, upload-time = "2026-08-10T01:55:04.758Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f1/12bb4b119cffb7fe5301b2d997ec9ffc1719637f6f4faf2ff2315e13b201/pyqwest-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e34d55a53492b44b82b690c2b11957fc35e99ebab4db2e9bcb2a1e2621d71b62", size = 5976516, upload-time = "2026-08-10T01:55:06.453Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/046dbf68ccedd816770fd212c6c2612372a6f0d7ecf2d8273480db460ddf/pyqwest-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:48c367150783f6866d0af43c209cc405f8287743d7b2472c7d757fda2478fd57", size = 4841470, upload-time = "2026-08-10T01:55:08.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/cd/38ff77d145385afd71b2dbd6eb116251ce3ffddbed0edde16c64394fbec2/pyqwest-0.9.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:10fae206270355c993b49c49bf9778995167f5efe591807d50a8e682921d71ea", size = 5222689, upload-time = "2026-08-10T01:55:09.639Z" },
+    { url = "https://files.pythonhosted.org/packages/82/95/d8c6804eeb72b7b89842b58f1f05d5cfda5be410c4a22442d2574d510d39/pyqwest-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5f475129fb792593222a9ce0fefbbc10bda1544a7411f3946d771c9a61c50e61", size = 5085846, upload-time = "2026-08-10T01:55:11.569Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e7/04fe8962ec416be0199093ebdd326653a5a7b8f53ddfdb29af81756f7c08/pyqwest-0.9.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78f6f676d349535cb094e8e3bcf33863238a142fb7dcc7afb9e61749e2351047", size = 5613296, upload-time = "2026-08-10T01:55:13.315Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0c/7a11728155a34838d2e7c78fb24c937f2cd844ec791ef416030c52f4bb5e/pyqwest-0.9.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f460f5fcdae8cc46e6a679128836f6cd47fbf4bf73e5c9d6ea868e4a90b2e7ee", size = 5557492, upload-time = "2026-08-10T01:55:15.103Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d5/8c6e68f0e978b5257b309809fec00d946c1ed20dacef97f25c23de5b91a9/pyqwest-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cba6804151e973d27c99b9f02b3f0bcab7270c3f99725b508ada9c147365cabd", size = 5774204, upload-time = "2026-08-10T01:55:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/17/20/fed89b62d50b4efad2ebe78c3867e0e402f824726652034728a5dd0a342e/pyqwest-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bc9dfeca326918d70a5368114de0fc627d9f64fafa36563ab484ae58ffe42c0d", size = 5964506, upload-time = "2026-08-10T01:55:19.031Z" },
+    { url = "https://files.pythonhosted.org/packages/11/de/30575019efebae84502269d097e706e89a30631e3719218b053e4e0dc179/pyqwest-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384693adc0908f16324e5b508a3c25fb9a92b88f9bdf7ccb6820507db4a95888", size = 4809013, upload-time = "2026-08-10T01:55:21.042Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/4e/46822676c7cfafbf510f2af84b510b6f3dc1f3c4df781a837ff75c7410fc/pyqwest-0.9.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c174d8ebde256c457f455dcdedf59446528d84874cb5967041be0d1bda05929", size = 5227559, upload-time = "2026-08-10T01:55:22.625Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/80/9d98ad770043e5dd3ad7b765f2acf911bd11b113e0280565277d2e707864/pyqwest-0.9.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d5e56192b03bca7ec511c9af4ed80fa10fc1c1871d0ccfe49050632785b46099", size = 5109747, upload-time = "2026-08-10T01:55:24.393Z" },
+    { url = "https://files.pythonhosted.org/packages/36/95/d1a88c8115c88f843b907e3d3bd1958eaef851cca023a47bba4257d974d9/pyqwest-0.9.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b3fa3c93638fc645c7c626fe83032f53972673581878bd85702842f41665ad6c", size = 5631597, upload-time = "2026-08-10T01:55:26.19Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/3a/e568f9cf9ff75ca45ce7323ac916d076f9f4df4e957404ff0f0d3286dbe0/pyqwest-0.9.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:869d1c630cbff38510207c5b57139f319acca21ed978f9ce6648fcd868df5fbd", size = 5573130, upload-time = "2026-08-10T01:55:28.351Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c9/a261dbf9a4fd3cfa790221957c5cbe0d52e75ff7403dd91254aa977164b1/pyqwest-0.9.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:a0bc2ba9b6d3103c6f0cce59cca9e2e294d1707bca435b471a1917db73010801", size = 5794377, upload-time = "2026-08-10T01:55:30.684Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a4/389a32479767cba432451f2913ff55bcab13981c5cf561028aa54ba97ae1/pyqwest-0.9.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:bfb04e3e91166fe6e4eecdcfccb0b2490da7629984b7988cfd4b11daa1dbb616", size = 5977476, upload-time = "2026-08-10T01:55:32.51Z" },
+    { url = "https://files.pythonhosted.org/packages/14/26/91891131d47e1d9ad652ae6ff010bc9169ab051f20d888cd3471d87f070c/pyqwest-0.9.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fbff11bbffb572c084ccd76048c40bd57976b255d34f59280e56626f556cfaeb", size = 4833070, upload-time = "2026-08-10T01:55:34.506Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/43/30e407989e313677dbb9d5f045f966549a7254834571e342eaa4b55cc67b/wcmatch-11.0.1.tar.gz", hash = "sha256:1ea2b4fa678b8ca268253798d5963935df39132d47c3e241c0a0732224005e7d", size = 144662, upload-time = "2026-08-14T15:20:40.477Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/77/7a02b0f05b3ffcdbef9719ce3ee0b508d6a29b58e95299f1580055671db3/wcmatch-11.0.1-py3-none-any.whl", hash = "sha256:fd149ecddb9f0a88ea780017d6dde17c994e494e7f7303d4e3c9d6251f978f4b", size = 43449, upload-time = "2026-08-14T15:20:39.379Z" },
+]

--- a/tests/run-examples.ts
+++ b/tests/run-examples.ts
@@ -127,6 +127,11 @@ const scripts: {
 // suite does not install Crabbox. Its unit tests cover command order and cleanup;
 // the real provider lifecycle remains a separate, explicitly approved smoke:
 //   crabbox-e2b-python
+// Orchestrates Hermes inside the separately published `hermes` template and
+// makes two provider calls so the agent can create and reuse a skill. Its unit
+// tests cover orchestration and cleanup; template/inference remains a separate,
+// explicitly approved smoke because this repository has no OpenRouter secret:
+//   hermes-incident-playbook-python
 // Runs a long-lived agent/server process rather than a script that exits, so
 // this runner can only ever time out on them:
 //   flue-feedback-analyst-js, vercel-eve-feedback-analyst-js,


### PR DESCRIPTION
## Summary

- add a Python Hermes + E2B incident playbook example
- demonstrate Hermes creating a reusable `incident-triage` skill and applying it in a fresh session
- include deterministic fixtures, unit coverage, and cookbook navigation

## Why

This example is designed around Hermes' distinctive self-improving loop: the first investigation learns a reusable procedure, while the second investigation demonstrates reuse in a new session. The two synthetic incidents make the learned decision rules observable.

## Validation

- `uv run python -m unittest discover -s tests -v` (3 tests)
- `uv run python -m compileall -q main.py tests`
- `git diff --check`
- paired with the live Hermes template smoke from INT-51

Provider-backed Hermes inference E2E was intentionally not run here because the repository does not contain a provider secret; `HERMES_TEMPLATE` supports tagged/private template smoke during development.

Linear: https://linear.app/e2b/issue/INT-51/hermes-template
