### PR TITLE
Fix the two failing nightly examples: mcp-claude-code-js under root, openai-js on a bad cell

### DIFF
--- a/.github/workflows/update-tests-md.yml
+++ b/.github/workflows/update-tests-md.yml
@@ -11,6 +11,14 @@ on:
         type: choice
         default: 'off'
         options: ['off', 'ok', 'failure']
+      examples:
+        description: >-
+          Space-separated substring filters, so a fix can be verified without
+          running all 31 examples and paying four providers for the privilege.
+          Leave empty to run everything. A filtered run does not post to Slack,
+          since a partial result read as a full one is worse than no message.
+        type: string
+        default: ''
       rebuild_templates:
         description: >-
           Rebuild the custom E2B templates instead of reusing existing ones.
@@ -61,7 +69,12 @@ jobs:
     - name: Run the examples and save results
       id: tests
       if: inputs.preview_message == '' || inputs.preview_message == 'off'
-      run: npm test
+      # Through the environment, not spliced into the command line: a dispatch
+      # input is attacker-controlled the moment write access is. Unquoted on
+      # purpose, so several filters still word-split into separate arguments.
+      run: npm test -- $EXAMPLES
+      env:
+        EXAMPLES: ${{ inputs.examples }}
       continue-on-error: true
 
     # Preview mode: synthesise the results instead of running anything, so the
@@ -107,7 +120,7 @@ jobs:
     # rather than failed when no webhook is configured, so forks and manual runs
     # do not go red over a missing secret.
     - name: Notify Slack
-      if: always() && env.SLACK_WEBHOOK != ''
+      if: always() && env.SLACK_WEBHOOK != '' && !inputs.examples
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       run: |

--- a/examples/mcp-claude-code-js/index.ts
+++ b/examples/mcp-claude-code-js/index.ts
@@ -12,6 +12,9 @@ async function runClaudeCodeExample() {
   
   // Create E2B sandbox with MCP servers
   const sandbox = await Sandbox.create({
+    // The research below is an open-ended agent run over two MCP servers, so it
+    // can outlive the 5 minute default and take the sandbox down with it.
+    timeoutMs: 600_000,
     envs: {
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
     },

--- a/examples/mcp-claude-code-js/index.ts
+++ b/examples/mcp-claude-code-js/index.ts
@@ -1,6 +1,12 @@
 import 'dotenv/config';
 import Sandbox from 'e2b';
 
+// Commands in an MCP-enabled sandbox default to root, in the gateway's own
+// directory (/etc/mcp-gateway). Claude Code refuses --dangerously-skip-permissions
+// under root, and /etc/mcp-gateway is not writable by anyone else, so every
+// command here runs as the regular sandbox user from that user's home.
+const asSandboxUser = { user: 'user', cwd: '/home/user' } as const;
+
 async function runClaudeCodeExample() {
   console.log('Creating E2B sandbox with Claude Code CLI and MCP servers...');
   
@@ -26,6 +32,7 @@ async function runClaudeCodeExample() {
   await sandbox.commands.run(
     `claude mcp add --transport http e2b-mcp-gateway ${mcpUrl} --header "Authorization: Bearer ${mcpToken}"`, 
     { 
+      ...asSandboxUser,
       timeoutMs: 0, 
       onStdout: console.log, 
       onStderr: console.log 
@@ -39,6 +46,7 @@ async function runClaudeCodeExample() {
   await sandbox.commands.run(
     `echo 'Use arxiv to search for a new paper about large language models and summarize it. Then use duckduckgo to find information about the main authors. Finally, create a minimal index.html page (in /web directory) outlining the paper and authors.' | claude -p --dangerously-skip-permissions`,
     { 
+      ...asSandboxUser,
       timeoutMs: 0, 
       onStdout: console.log, 
       onStderr: console.log 
@@ -49,6 +57,7 @@ async function runClaudeCodeExample() {
   await sandbox.commands.run(
     'python3 -m http.server 3000 -d web', 
     { 
+      ...asSandboxUser,
       background: true, 
       timeoutMs: 0, 
       onStdout: console.log, 

--- a/examples/mcp-claude-code-js/index.ts
+++ b/examples/mcp-claude-code-js/index.ts
@@ -1,12 +1,6 @@
 import 'dotenv/config';
 import Sandbox from 'e2b';
 
-// Commands in an MCP-enabled sandbox default to root, in the gateway's own
-// directory (/etc/mcp-gateway). Claude Code refuses --dangerously-skip-permissions
-// under root, and /etc/mcp-gateway is not writable by anyone else, so every
-// command here runs as the regular sandbox user from that user's home.
-const asSandboxUser = { user: 'user', cwd: '/home/user' } as const;
-
 async function runClaudeCodeExample() {
   console.log('Creating E2B sandbox with Claude Code CLI and MCP servers...');
   
@@ -17,6 +11,12 @@ async function runClaudeCodeExample() {
     timeoutMs: 600_000,
     envs: {
       ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
+      // Commands in an MCP-enabled sandbox run as root, and Claude Code refuses
+      // --dangerously-skip-permissions under root. IS_SANDBOX is the supported
+      // way to say "this whole machine is the sandbox", which is exactly true
+      // here. Note --allow-dangerously-skip-permissions does not do this: it
+      // offers the bypass without enabling it, and is still refused under root.
+      IS_SANDBOX: '1',
     },
     mcp: {
       duckduckgo: {},
@@ -35,7 +35,6 @@ async function runClaudeCodeExample() {
   await sandbox.commands.run(
     `claude mcp add --transport http e2b-mcp-gateway ${mcpUrl} --header "Authorization: Bearer ${mcpToken}"`, 
     { 
-      ...asSandboxUser,
       timeoutMs: 0, 
       onStdout: console.log, 
       onStderr: console.log 
@@ -49,7 +48,6 @@ async function runClaudeCodeExample() {
   await sandbox.commands.run(
     `echo 'Use arxiv to search for a new paper about large language models and summarize it. Then use duckduckgo to find information about the main authors. Finally, create a minimal index.html page (in /web directory) outlining the paper and authors.' | claude -p --dangerously-skip-permissions`,
     { 
-      ...asSandboxUser,
       timeoutMs: 0, 
       onStdout: console.log, 
       onStderr: console.log 
@@ -60,7 +58,6 @@ async function runClaudeCodeExample() {
   await sandbox.commands.run(
     'python3 -m http.server 3000 -d web', 
     { 
-      ...asSandboxUser,
       background: true, 
       timeoutMs: 0, 
       onStdout: console.log, 

--- a/examples/mcp-claude-code-js/index.ts
+++ b/examples/mcp-claude-code-js/index.ts
@@ -46,7 +46,7 @@ async function runClaudeCodeExample() {
   
   // Run Claude Code with research task
   await sandbox.commands.run(
-    `echo 'Use arxiv to search for a new paper about large language models and summarize it. Then use duckduckgo to find information about the main authors. Finally, create a minimal index.html page (in /web directory) outlining the paper and authors.' | claude -p --dangerously-skip-permissions`,
+    `echo 'Use arxiv to search for a new paper about large language models and summarize it. Then use duckduckgo to find information about the main authors. Finally, create a minimal index.html page at the absolute path /web/index.html outlining the paper and authors.' | claude -p --dangerously-skip-permissions`,
     { 
       timeoutMs: 0, 
       onStdout: console.log, 
@@ -55,8 +55,11 @@ async function runClaudeCodeExample() {
   );
 
   console.log('Starting web server to host the research results...');
+  // Absolute on both sides, matching the path the prompt above pins. A relative
+  // 'web' resolves against the command's cwd, which is the gateway's own
+  // directory, so the server came up on an empty root and the printed link 404d.
   await sandbox.commands.run(
-    'python3 -m http.server 3000 -d web', 
+    'python3 -m http.server 3000 -d /web', 
     { 
       background: true, 
       timeoutMs: 0, 

--- a/examples/openai-js/app.ts
+++ b/examples/openai-js/app.ts
@@ -1,11 +1,17 @@
 import fs from 'node:fs'
 import OpenAI from 'openai'
-import type { ChatCompletionTool } from 'openai/resources/chat/completions'
+import type { ChatCompletionMessageParam, ChatCompletionTool } from 'openai/resources/chat/completions'
 import { Sandbox, Result } from '@e2b/code-interpreter'
+import type { Execution } from '@e2b/code-interpreter'
 import { OutputMessage } from '@e2b/code-interpreter'
 import * as dotenv from 'dotenv'
 
 dotenv.config()
+
+// The model writes the Python, so it will sometimes write Python that does not
+// parse or that throws. Hand the traceback back and let it fix its own cell,
+// the way a person would - one bad cell should not end the run.
+const MAX_TURNS = 4
 
 const MODEL_NAME = 'gpt-5.6-terra' // Choose a different model by uncommenting. It needs function-calling support on
 // /v1/chat/completions - gpt-5.6-terra and gpt-5.6-luna do, gpt-5.6-sol does not.
@@ -57,64 +63,80 @@ const tools: ChatCompletionTool[] = [
     }
 ]
 
-async function codeInterpret(codeInterpreter: Sandbox, code: string): Promise<Result[]> {
+// Returns the whole execution, errors included, so the caller can decide
+// whether to give up or hand the traceback back to the model.
+async function codeInterpret(codeInterpreter: Sandbox, code: string): Promise<Execution> {
     console.log('Running code interpreter...')
 
-    const exec = await codeInterpreter.runCode(code, {
+    return await codeInterpreter.runCode(code, {
         onStderr: (msg: OutputMessage) => console.log('[Code Interpreter stderr]', msg),
         onStdout: (stdout: OutputMessage) => console.log('[Code Interpreter stdout]', stdout),
     })
-
-    if (exec.error) {
-        console.log('[Code Interpreter ERROR]', exec.error)
-        throw new Error(exec.error.value)
-    }
-    return exec.results
 }
 
 const client = new OpenAI()
 
-async function processToolCall(codeInterpreter: Sandbox, toolCall: any): Promise<Result[]> {
+async function processToolCall(codeInterpreter: Sandbox, toolCall: any): Promise<Execution | null> {
     if (toolCall.function.name === 'execute_python') {
         const toolInput = JSON.parse(toolCall.function.arguments)
         return await codeInterpret(codeInterpreter, toolInput.code)
     }
-    return []
+    return null
 }
 
 async function chatWithLLM(codeInterpreter: Sandbox, userMessage: string): Promise<Result[]> {
     console.log(`\n${'='.repeat(50)}\nUser Message: ${userMessage}\n${'='.repeat(50)}`)
 
-    console.log('Waiting for the LLM to respond...')
-    const completion = await client.chat.completions.create({
-        model: MODEL_NAME,
-        messages: [
-            { role: 'system', content: SYSTEM_PROMPT },
-            { role: 'user', content: userMessage }
-        ],
-        // gpt-5.6-* are reasoning models; function tools on chat.completions
-        // require reasoning_effort 'none' (or the /v1/responses API).
-        reasoning_effort: 'none',
-        tools: tools,
-        tool_choice: 'auto'
-    })
+    const messages: ChatCompletionMessageParam[] = [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: userMessage }
+    ]
 
-    const message = completion.choices[0].message
-    console.log('\nInitial Response:', message)
+    for (let turn = 1; turn <= MAX_TURNS; turn++) {
+        console.log(`\nWaiting for the LLM to respond (turn ${turn}/${MAX_TURNS})...`)
+        const completion = await client.chat.completions.create({
+            model: MODEL_NAME,
+            messages,
+            // gpt-5.6-* are reasoning models; function tools on chat.completions
+            // require reasoning_effort 'none' (or the /v1/responses API).
+            reasoning_effort: 'none',
+            tools: tools,
+            tool_choice: 'auto'
+        })
 
-    if (message.tool_calls) {
+        const message = completion.choices[0].message
+        console.log('\nResponse:', message)
+        messages.push(message)
+
+        // Deliberately a failure: with no tool call there was no code to run, so the
+        // example demonstrated nothing. A missing *chart* is fine; missing code is not.
+        if (!message.tool_calls?.length) {
+            throw new Error('The model returned no tool call, so there was no code to execute.')
+        }
+
         const toolCall = message.tool_calls[0]
         // v7 widened tool_calls to a union of function and custom tool calls.
         if (toolCall.type !== 'function') throw new Error('Expected a function tool call.')
         console.log(`\nTool Used: ${toolCall.function.name}\nTool Input: ${toolCall.function.arguments}`)
 
-        const codeInterpreterResults = await processToolCall(codeInterpreter, toolCall)
-        console.log(`Tool Result: ${codeInterpreterResults}`)
-        return codeInterpreterResults
+        const execution = await processToolCall(codeInterpreter, toolCall)
+        if (!execution) throw new Error(`The model called an unknown tool: ${toolCall.function.name}`)
+
+        if (execution.error) {
+            console.log('[Code Interpreter ERROR]', execution.error)
+            messages.push({
+                role: 'tool',
+                tool_call_id: toolCall.id,
+                content: `The cell failed.\n${execution.error.name}: ${execution.error.value}\n\n${execution.error.traceback}\n\nFix the code and call execute_python again.`
+            })
+            continue
+        }
+
+        console.log(`Tool Result: ${execution.results}`)
+        return execution.results
     }
-    // Deliberately a failure: with no tool call there was no code to run, so the
-    // example demonstrated nothing. A missing *chart* is fine; missing code is not.
-    throw new Error('The model returned no tool call, so there was no code to execute.')
+
+    throw new Error(`The model did not produce runnable code within ${MAX_TURNS} turns.`)
 }
 
 async function uploadDataset(codeInterpreter: Sandbox): Promise<string> {

--- a/tests/run-examples.ts
+++ b/tests/run-examples.ts
@@ -149,6 +149,11 @@ const TIMEOUT_OVERRIDES: Record<string, number> = {
   'openai-codex-in-sandbox-js': 600_000,
   'openai-codex-in-sandbox-python': 600_000,
   'playwright-in-e2b': 300_000,
+  // Same shape: Claude Code doing multi-step research over two MCP servers
+  // (arxiv, duckduckgo) before it writes the page. It fit the shared budget
+  // only by accident - 112s of 150s on its last green run - so one slow arxiv
+  // search was always going to end it, and one did.
+  'mcp-claude-code-js': 600_000,
 }
 
 // Examples that run from a custom template need it built on the account first.


### PR DESCRIPTION
## Summary

Nightly run [32675477347](https://github.com/e2b-dev/e2b-cookbook/actions/runs/32675477347) failed 2 of 31 examples, for two unrelated reasons. Fixing the first uncovered two more behind it.

`mcp-claude-code-js` died on Claude Code refusing `--dangerously-skip-permissions`, because commands in an `mcp:`-enabled sandbox run as **root**; on the last green run ([32034594462](https://github.com/e2b-dev/e2b-cookbook/actions/runs/32034594462), same example code, same e2b 2.38.3) they ran as `user` in `/home/user`. The example now sets `IS_SANDBOX=1`, which is the supported way to tell Claude Code the whole machine is the sandbox. Tested live: `--allow-dangerously-skip-permissions` is not an alternative, since it offers the bypass without enabling it and is still refused under root. Only `IS_SANDBOX` gets past the check.

That exposed the 150s shared per-example budget. This example fit it only by accident, 112s of 150s on its last green run, so one slow arxiv search was always going to end it and one did. It now gets the same 600s the other agent-CLI examples get, and raises its own sandbox lifetime past the 5 minute default so an open-ended research run does not take the sandbox down mid-command. It has since run at 187s and 327s, both over the old budget.

Running as root then exposed a bug the old `user` default had been hiding: root can write `/`, so Claude takes "in /web directory" literally and the page lands at `/web/index.html`, while the server was told to serve a relative `web` resolved against the command cwd of `/etc/mcp-gateway`. Reproduced directly against a live sandbox: `-d web` returns **404**, `-d /web` returns **200**. CI never caught it because the server starts in the background, so the example exits 0 with a dead link. The path is now absolute on both sides. Worth noting `/etc/mcp-gateway` also holds the gateway bearer token at `.token`, so an example that served its cwd would publish that directory; the absolute path removes the adjacency.

`openai-js` was model nondeterminism, not a bug: the model emitted Python with an unbalanced paren and the example took exactly one turn, so one bad cell ended the run. `chatWithLLM` is now a bounded loop (4 turns) that hands the traceback back as a tool result and lets the model repair its own cell.

Also adds an `examples` dispatch input, so a fix can be verified against one example instead of all 31 across four providers, which the existing comments already ask for. A filtered run does not post to Slack, since a partial result read as a full one is worse than no message. The input reaches the shell through the environment rather than spliced into the command line.

One thing this PR does not fix. Claude Code reports that neither the arxiv nor the duckduckgo MCP tool is available in session and falls back to curl and web search, so the example passes without exercising the gateway it is named after. The gateway itself is fine: a direct `tools/list` returns all six tools and `claude mcp list` reports it connected. This is not introduced here. The leading suspicion is `hasTrustDialogAccepted: false` on the project entry, with `--mcp-config` plus `--strict-mcp-config` as the likely fix, but that is unverified and left for a follow-up rather than shipped blind.